### PR TITLE
Feature/#42 저장된 활동들을 전체 조회

### DIFF
--- a/backend/emm-sale/src/main/java/com/emmsale/career/api/CareerApi.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/career/api/CareerApi.java
@@ -1,0 +1,24 @@
+package com.emmsale.career.api;
+
+import com.emmsale.career.application.CareerService;
+import com.emmsale.career.application.dto.CareerResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/careers")
+@RequiredArgsConstructor
+public class CareerApi {
+
+  private final CareerService careerService;
+
+  @GetMapping
+  public ResponseEntity<List<CareerResponse>> findAll(){
+    return ResponseEntity.ok(careerService.findAll());
+  }
+}
+

--- a/backend/emm-sale/src/main/java/com/emmsale/career/application/CareerService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/career/application/CareerService.java
@@ -1,5 +1,7 @@
 package com.emmsale.career.application;
 
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 
 import com.emmsale.career.application.dto.ActivityResponse;
@@ -8,10 +10,9 @@ import com.emmsale.career.domain.ActivityType;
 import com.emmsale.career.domain.Career;
 import com.emmsale.career.domain.CareerRepository;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -22,9 +23,12 @@ public class CareerService {
   private final CareerRepository careerRepository;
 
   public List<CareerResponse> findAll() {
-    final Map<ActivityType, List<Career>> groupByActivityType = careerRepository.findAll()
+    final EnumMap<ActivityType, List<Career>> groupByActivityType = careerRepository.findAll()
         .stream()
-        .collect(Collectors.groupingBy(Career::getActivityType));
+        .sorted(comparing(career -> career.getName().toLowerCase()))
+        .collect(
+            groupingBy(Career::getActivityType, () -> new EnumMap<>(ActivityType.class), toList())
+        );
 
     final List<CareerResponse> responses = new ArrayList<>();
 

--- a/backend/emm-sale/src/main/java/com/emmsale/career/application/CareerService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/career/application/CareerService.java
@@ -1,0 +1,42 @@
+package com.emmsale.career.application;
+
+import static java.util.stream.Collectors.toList;
+
+import com.emmsale.career.application.dto.ActivityResponse;
+import com.emmsale.career.application.dto.CareerResponse;
+import com.emmsale.career.domain.ActivityType;
+import com.emmsale.career.domain.Career;
+import com.emmsale.career.domain.CareerRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CareerService {
+
+  private final CareerRepository careerRepository;
+
+  public List<CareerResponse> findAll() {
+    final Map<ActivityType, List<Career>> groupByActivityType = careerRepository.findAll()
+        .stream()
+        .collect(Collectors.groupingBy(Career::getActivityType));
+
+    final List<CareerResponse> responses = new ArrayList<>();
+
+    for (final Entry<ActivityType, List<Career>> entry : groupByActivityType.entrySet()) {
+      final List<ActivityResponse> activityResponse = entry.getValue()
+          .stream()
+          .map(it -> new ActivityResponse(it.getId(), it.getName()))
+          .collect(toList());
+
+      responses.add(new CareerResponse(entry.getKey().getValue(), activityResponse));
+    }
+
+    return responses;
+  }
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/career/application/dto/ActivityResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/career/application/dto/ActivityResponse.java
@@ -1,0 +1,15 @@
+package com.emmsale.career.application.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ActivityResponse {
+
+  private final Long id;
+  private final String name;
+
+  public ActivityResponse(final Long id, final String name) {
+    this.id = id;
+    this.name = name;
+  }
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/career/application/dto/CareerResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/career/application/dto/CareerResponse.java
@@ -1,0 +1,16 @@
+package com.emmsale.career.application.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class CareerResponse {
+
+  private final String activityName;
+  private final List<ActivityResponse> activityResponses;
+
+  public CareerResponse(final String activityName, final List<ActivityResponse> activityResponses) {
+    this.activityName = activityName;
+    this.activityResponses = activityResponses;
+  }
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/career/domain/ActivityType.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/career/domain/ActivityType.java
@@ -1,15 +1,18 @@
 package com.emmsale.career.domain;
 
-public enum Activity {
+import lombok.Getter;
+
+@Getter
+public enum ActivityType {
 
   CLUB("동아리"),
   CONFERENCE("컨퍼런스"),
   EDUCATION("교육"),
-  JOB("분야");
+  JOB("직무");
 
   private final String value;
 
-  Activity(final String value) {
+  ActivityType(final String value) {
     this.value = value;
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/career/domain/Career.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/career/domain/Career.java
@@ -8,10 +8,12 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Career {
 
   @Id
@@ -20,7 +22,7 @@ public class Career {
 
   @Enumerated(EnumType.STRING)
   @Column(name = "activity", nullable = false)
-  private Activity activity;
+  private ActivityType activityType;
 
   @Column(nullable = false)
   private String name;

--- a/backend/emm-sale/src/main/java/com/emmsale/career/domain/CareerRepository.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/career/domain/CareerRepository.java
@@ -1,0 +1,7 @@
+package com.emmsale.career.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CareerRepository extends JpaRepository<Career, Long> {
+
+}

--- a/backend/emm-sale/src/main/resources/application.yml
+++ b/backend/emm-sale/src/main/resources/application.yml
@@ -4,6 +4,9 @@ spring:
       username: root
       password: 1234
       driver-class-name: com.mysql.cj.jdbc.Driver
+  sql:
+    init:
+      mode: always
   jpa:
     hibernate:
       ddl-auto: validate

--- a/backend/emm-sale/src/main/resources/data.sql
+++ b/backend/emm-sale/src/main/resources/data.sql
@@ -1,0 +1,39 @@
+truncate table kerdy.career;
+truncate table kerdy.member;
+truncate table kerdy.member_career;
+
+insert into career(id, activity, name)
+values (1, 'CLUB', 'YAPP');
+
+insert into career(id, activity, name)
+values (2, 'CLUB', 'DND');
+
+insert into career(id, activity, name)
+values (3, 'CLUB', 'nexters');
+
+insert into career(id, activity, name)
+values (4, 'CONFERENCE', '인프콘');
+
+insert into career(id, activity, name)
+values (5, 'EDUCATION', '우아한테크코스');
+
+insert into career(id, activity, name)
+values (6, 'JOB', 'Backend');
+
+insert into member(id, name, created_at, updated_at)
+values (1, 'member1', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP());
+
+insert into member(id, name, created_at, updated_at)
+values (2, 'member2', CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP());
+
+insert into member_career(id, career_id, member_id, created_at, updated_at)
+values (1, 1, 1, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP());
+
+insert into member_career(id, career_id, member_id, created_at, updated_at)
+values (2, 2, 1, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP());
+
+insert into member_career(id, career_id, member_id, created_at, updated_at)
+values (3, 3, 1, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP());
+
+insert into member_career(id, career_id, member_id, created_at, updated_at)
+values (4, 1, 2, CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP());

--- a/backend/emm-sale/src/main/resources/http/careers.http
+++ b/backend/emm-sale/src/main/resources/http/careers.http
@@ -1,0 +1,1 @@
+GET http://localhost:8080/careers

--- a/backend/emm-sale/src/main/resources/schema.sql
+++ b/backend/emm-sale/src/main/resources/schema.sql
@@ -1,3 +1,7 @@
+drop table if exists kerdy.career;
+drop table if exists kerdy.member;
+drop table if exists kerdy.member_career;
+
 create table kerdy.career
 (
     id       bigint auto_increment primary key,
@@ -19,5 +23,5 @@ create table kerdy.member_career
     created_at datetime(6) not null,
     updated_at datetime(6) not null,
     career_id  bigint not null,
-    member_id  bigint not null,
+    member_id  bigint not null
 );

--- a/backend/emm-sale/src/test/java/com/emmsale/career/api/CareerApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/career/api/CareerApiTest.java
@@ -1,0 +1,30 @@
+package com.emmsale.career.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.emmsale.career.application.CareerService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(CareerApi.class)
+class CareerApiTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private CareerService careerService;
+
+  @Test
+  @DisplayName("커리어를 전제 조회할 수 있으면 200 OK를 반환한다.")
+  void findAll() throws Exception {
+    // when & then
+    mockMvc.perform(get("/careers"))
+        .andExpect(status().isOk());
+  }
+}

--- a/backend/emm-sale/src/test/java/com/emmsale/career/application/CareerServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/career/application/CareerServiceTest.java
@@ -1,0 +1,59 @@
+package com.emmsale.career.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.emmsale.career.application.dto.ActivityResponse;
+import com.emmsale.career.application.dto.CareerResponse;
+import com.emmsale.career.domain.ActivityType;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CareerServiceTest {
+
+  @Autowired
+  private CareerService careerService;
+
+  @Test
+  @DisplayName("존재하고 있는 커리어를 전체 조회할 수 있다.")
+  void findAll() throws Exception {
+    //given
+    final List<String> expectedActivities = List.of(
+        ActivityType.CLUB.getValue(),
+        ActivityType.CONFERENCE.getValue(),
+        ActivityType.JOB.getValue(),
+        ActivityType.EDUCATION.getValue()
+    );
+
+    final List<String> expectedCareerNames = List.of(
+        "YAPP", "DND",
+        "nexters", "인프콘",
+        "우아한테크코스", "Backend"
+    );
+
+    //when
+    List<CareerResponse> careerResponses = careerService.findAll();
+
+    //then
+    final List<String> actualCareerNames = careerResponses.stream()
+        .flatMap(it -> it.getActivityResponses().stream())
+        .map(ActivityResponse::getName)
+        .collect(Collectors.toList());
+
+    assertAll(
+        () -> assertThat(careerResponses).hasSize(4),
+        () -> assertThat(careerResponses)
+            .extracting("activityName")
+            .containsExactlyInAnyOrderElementsOf(expectedActivities),
+        () -> assertThat(expectedCareerNames)
+            .containsExactlyInAnyOrderElementsOf(actualCareerNames)
+    );
+  }
+
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- #42 

## 📝작업 내용
- data.sql, schema.sql 를 통해 mock data 생성
- application.yml 에서 sql.init.mode always로 변경
- careers.http 생성
- 처음 사용자가 정보를 등록하기 위해서 필요한 "선택 정보들" 조회하는 API 구현


### 스크린샷
![image](https://github.com/woowacourse-teams/2023-emmsale/assets/62413589/ff1dd0fa-4298-4c70-b2eb-9e54cd862c68)

close #42 