### PR TITLE
Feature/#41 깃허브 로그인 기능 구현

### DIFF
--- a/backend/emm-sale/src/main/java/com/emmsale/login/application/GithubClient.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/login/application/GithubClient.java
@@ -2,12 +2,14 @@ package com.emmsale.login.application;
 
 import com.emmsale.login.application.dto.GithubAccessTokenRequest;
 import com.emmsale.login.application.dto.GithubAccessTokenResponse;
+import com.emmsale.login.application.dto.GithubProfileResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 @Component
@@ -45,5 +47,22 @@ public class GithubClient {
       throw new IllegalArgumentException("code가 유효하지 않습니다.");
     }
     return accessToken;
+  }
+
+  public GithubProfileResponse getGithubProfileFromGithub(final String accessToken) {
+    final HttpHeaders headers = new HttpHeaders();
+    headers.add("Authorization", "token " + accessToken);
+
+    final HttpEntity httpEntity = new HttpEntity(headers);
+    final RestTemplate restTemplate = new RestTemplate();
+
+    try {
+      return restTemplate
+          .exchange(profileUrl, HttpMethod.GET, httpEntity, GithubProfileResponse.class)
+          .getBody();
+    } catch (final HttpClientErrorException e) {
+      //TODO: 커스텀 예외 정의
+      throw new IllegalArgumentException("요청이 유효하지 않습니다.");
+    }
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/login/application/GithubClient.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/login/application/GithubClient.java
@@ -1,0 +1,49 @@
+package com.emmsale.login.application;
+
+import com.emmsale.login.application.dto.GithubAccessTokenRequest;
+import com.emmsale.login.application.dto.GithubAccessTokenResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class GithubClient {
+
+  @Value("${github.client.id}")
+  private String clientId;
+  @Value("${github.client.secret}")
+  private String clientSecret;
+  @Value("${github.url.access-token}")
+  private String accessTokenUrl;
+  @Value("${github.url.profile}")
+  private String profileUrl;
+
+  public String getAccessTokenFromGithub(final String code) {
+    final GithubAccessTokenRequest githubAccessTokenRequest = new GithubAccessTokenRequest(
+        code,
+        clientId,
+        clientSecret
+    );
+
+    final HttpHeaders headers = new HttpHeaders();
+    headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+
+    final HttpEntity httpEntity = new HttpEntity(githubAccessTokenRequest, headers);
+    final RestTemplate restTemplate = new RestTemplate();
+
+    final String accessToken = restTemplate
+        .exchange(accessTokenUrl, HttpMethod.POST, httpEntity, GithubAccessTokenResponse.class)
+        .getBody()
+        .getAccessToken();
+
+    if (accessToken == null) {
+      //TODO: 커스텀 예외 정의
+      throw new IllegalArgumentException("code가 유효하지 않습니다.");
+    }
+    return accessToken;
+  }
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/login/application/LoginService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/login/application/LoginService.java
@@ -1,0 +1,29 @@
+package com.emmsale.login.application;
+
+import com.emmsale.login.application.dto.GithubProfileResponse;
+import com.emmsale.login.application.dto.TokenResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LoginService {
+
+  private final GithubClient githubClient;
+
+  public LoginService(final GithubClient githubClient) {
+    this.githubClient = githubClient;
+  }
+
+  public TokenResponse createToken(final String code) {
+    final String githubAccessToken = githubClient.getAccessTokenFromGithub(code);
+    final GithubProfileResponse githubProfileFromGithub = githubClient.getGithubProfileFromGithub(
+        githubAccessToken);
+
+    //TODO: memberId 조회
+    final Long githubId = githubProfileFromGithub.getGithubId();
+    final Long memberId = 1L;
+    //TODO: accessToken 생성
+    final String accessToken = "";
+
+    return new TokenResponse(memberId, accessToken);
+  }
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/login/application/dto/GithubAccessTokenRequest.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/login/application/dto/GithubAccessTokenRequest.java
@@ -1,0 +1,16 @@
+package com.emmsale.login.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class GithubAccessTokenRequest {
+
+  private final String code;
+  @JsonProperty("client_id")
+  private final String clientId;
+  @JsonProperty("client_secret")
+  private final String clientSecret;
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/login/application/dto/GithubAccessTokenResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/login/application/dto/GithubAccessTokenResponse.java
@@ -1,0 +1,20 @@
+package com.emmsale.login.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class GithubAccessTokenResponse {
+
+  @JsonProperty("access_token")
+  private String accessToken;
+  @JsonProperty("token_type")
+  private String tokenType;
+  private String scope;
+  private String bearer;
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/login/application/dto/GithubProfileResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/login/application/dto/GithubProfileResponse.java
@@ -1,0 +1,26 @@
+package com.emmsale.login.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class GithubProfileResponse {
+
+  @JsonProperty("id")
+  private String githubId;
+  @JsonProperty("name")
+  private String name;
+  @JsonProperty("login")
+  private String username;
+  @JsonProperty("avatar_url")
+  private String imageUrl;
+
+  public Long getGithubId() {
+    return Long.valueOf(githubId);
+  }
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/login/application/dto/TokenResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/login/application/dto/TokenResponse.java
@@ -1,0 +1,15 @@
+package com.emmsale.login.application.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TokenResponse {
+
+  private Long memberId;
+  private String accessToken;
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/login/ui/LoginController.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/login/ui/LoginController.java
@@ -1,0 +1,28 @@
+package com.emmsale.login.ui;
+
+import com.emmsale.login.application.LoginService;
+import com.emmsale.login.application.dto.TokenResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/login")
+public class LoginController {
+
+  private final LoginService loginService;
+
+  public LoginController(final LoginService loginService) {
+    this.loginService = loginService;
+  }
+
+  @GetMapping("/github/callback")
+  public ResponseEntity<TokenResponse> login(@RequestParam final String code) {
+    if (code == null) {
+      return ResponseEntity.badRequest().build();
+    }
+    return ResponseEntity.ok().body(loginService.createToken(code));
+  }
+}

--- a/backend/emm-sale/src/main/resources/application.yml
+++ b/backend/emm-sale/src/main/resources/application.yml
@@ -21,3 +21,11 @@ logging:
           descriptor:
             sql:
               BasicBinder: TRACE
+
+github:
+  client:
+    id: client_id
+    secret: client_secret
+  url:
+    access-token: access-token_url
+    profile: profile_url

--- a/backend/emm-sale/src/test/java/com/emmsale/login/ui/LoginControllerTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/login/ui/LoginControllerTest.java
@@ -1,0 +1,56 @@
+package com.emmsale.login.ui;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.emmsale.login.application.LoginService;
+import com.emmsale.login.application.dto.TokenResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(LoginController.class)
+class LoginControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private LoginService loginService;
+
+  @Test
+  @DisplayName("code가 유효할 경우 200과 함께 TokenResponse를 반환해 준다.")
+  void availableLoginTest() throws Exception {
+    // given
+    final String code = "code1234";
+    final TokenResponse tokenResponse = new TokenResponse(1L, "access_token");
+
+    given(loginService.createToken(code)).willReturn(tokenResponse);
+
+    // when
+    final ResultActions result = mockMvc.perform(
+        get("/login/github/callback").param("code", code)
+    );
+
+    // then
+    result.andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("code가 존재하지 않을 경우 400 BadRequest를 반환한다.")
+  void illegalLoginTest() throws Exception {
+    // when
+    final ResultActions result = mockMvc.perform(get("/login/github/callback"));
+
+    // then
+    result.andExpect(status().isBadRequest())
+        .andDo(print());
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- #41 

## 📝작업 내용
깃허브 redirect uri로 요청이 들어왔을 때 토큰을 반환하는 기능 구현
사용자를 조회하고 토큰을 생성하는 로직은 다음 이슈에서 진행 예정 (`TODO` 참고)

## 💬리뷰 요구사항(선택)
작업의 범위가 모호하여 로그인 기능을 위한 틀만 구현했습니다.
커스텀 예외는 아직 논의되지 않아 `TODO` 주석만 남겨두고 넘어갔습니다.
기능 구현에 미흡한 점 있으면 말씀해 주세요.