### PR TITLE
Feature/#114 한줄 자기소개 수정 기능 구현

### DIFF
--- a/backend/emm-sale/src/docs/asciidoc/index.adoc
+++ b/backend/emm-sale/src/docs/asciidoc/index.adoc
@@ -166,6 +166,17 @@ include::{snippets}/update-open-profile-url/http-request.adoc[]
 .HTTP response
 include::{snippets}/update-open-profile-url/http-response.adoc[]
 
+=== `PUT`: 사용자의 한줄 자기소개 업데이트
+
+.HTTP request 설명
+include::{snippets}/update-description/request-fields.adoc[]
+
+.HTTP request
+include::{snippets}/update-description/http-request.adoc[]
+
+.HTTP response
+include::{snippets}/update-description/http-response.adoc[]
+
 == Event
 
 === `GET` : 행사 상세정보 조회

--- a/backend/emm-sale/src/main/java/com/emmsale/member/api/MemberApi.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/api/MemberApi.java
@@ -2,6 +2,7 @@ package com.emmsale.member.api;
 
 import com.emmsale.member.application.MemberActivityService;
 import com.emmsale.member.application.MemberUpdateService;
+import com.emmsale.member.application.dto.DescriptionRequest;
 import com.emmsale.member.application.dto.MemberActivityAddRequest;
 import com.emmsale.member.application.dto.MemberActivityDeleteRequest;
 import com.emmsale.member.application.dto.MemberActivityInitialRequest;
@@ -65,6 +66,15 @@ public class MemberApi {
       @RequestBody @Valid final OpenProfileUrlRequest openProfileUrlRequest
   ) {
     memberUpdateService.updateOpenProfileUrl(member, openProfileUrlRequest);
+    return ResponseEntity.noContent().build();
+  }
+
+  @PutMapping("/members/description")
+  public ResponseEntity<Void> updateDescription(
+      final Member member,
+      @RequestBody final DescriptionRequest descriptionRequest
+  ) {
+    memberUpdateService.updateDescription(member, descriptionRequest);
     return ResponseEntity.noContent().build();
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/member/application/MemberUpdateService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/application/MemberUpdateService.java
@@ -1,8 +1,11 @@
 package com.emmsale.member.application;
 
+import com.emmsale.member.application.dto.DescriptionRequest;
 import com.emmsale.member.application.dto.OpenProfileUrlRequest;
 import com.emmsale.member.domain.Member;
 import com.emmsale.member.domain.MemberRepository;
+import com.emmsale.member.exception.MemberException;
+import com.emmsale.member.exception.MemberExceptionType;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,6 +15,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MemberUpdateService {
 
+  public static final int MAX_DESCRIPTION_LENGTH = 100;
+  public static final String DEFAULT_DESCRIPTION = "";
   private final MemberRepository memberRepository;
 
   public void updateOpenProfileUrl(
@@ -22,5 +27,24 @@ public class MemberUpdateService {
     final String openProfileUrl = openProfileUrlRequest.getOpenProfileUrl();
 
     persistMember.updateOpenProfileUrl(openProfileUrl);
+  }
+
+  public void updateDescription(final Member member, final DescriptionRequest descriptionRequest) {
+    String description = descriptionRequest.getDescription();
+    validateDescription(description);
+
+    final Member persistMember = memberRepository.findById(member.getId()).get();
+
+    if (description.isBlank()) {
+      persistMember.updateDescription(DEFAULT_DESCRIPTION);
+      return;
+    }
+    persistMember.updateDescription(description);
+  }
+
+  private void validateDescription(final String description) {
+    if (description.length() > MAX_DESCRIPTION_LENGTH) {
+      throw new MemberException(MemberExceptionType.OVER_LENGTH_DESCRIPTION);
+    }
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/member/application/dto/DescriptionRequest.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/application/dto/DescriptionRequest.java
@@ -1,0 +1,15 @@
+package com.emmsale.member.application.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DescriptionRequest {
+
+  private String description;
+
+  public DescriptionRequest(final String description) {
+    this.description = description;
+  }
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/member/domain/Member.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/domain/Member.java
@@ -9,7 +9,10 @@ import javax.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 
+@DynamicInsert
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,7 +25,8 @@ public class Member extends BaseEntity {
   private Long githubId;
   @Column(nullable = false)
   private String name;
-  @Column
+  @Column(nullable = false)
+  @ColumnDefault("")
   private String description;
   @Column
   private String openProfileUrl;
@@ -34,12 +38,14 @@ public class Member extends BaseEntity {
     this.githubId = githubId;
     this.imageUrl = imageUrl;
     this.name = name;
+    this.description = "";
   }
 
   public Member(final Long githubId, final String imageUrl, final String name) {
     this.githubId = githubId;
     this.imageUrl = imageUrl;
     this.name = name;
+    this.description = "";
   }
 
   public void updateName(final String name) {
@@ -48,6 +54,10 @@ public class Member extends BaseEntity {
 
   public void updateOpenProfileUrl(final String openProfileUrl) {
     this.openProfileUrl = openProfileUrl;
+  }
+
+  public void updateDescription(final String description) {
+    this.description = description;
   }
 
   public boolean isNotMe(final Member member) {

--- a/backend/emm-sale/src/main/java/com/emmsale/member/exception/MemberExceptionType.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/exception/MemberExceptionType.java
@@ -10,6 +10,11 @@ public enum MemberExceptionType implements BaseExceptionType {
       "해당 멤버는 존재하지 않습니다."
   ),
 
+  OVER_LENGTH_DESCRIPTION(
+      HttpStatus.BAD_REQUEST,
+      "한줄 자기소개에 입력 가능한 글자 수를 초과했습니다."
+  ),
+
   INVALID_CAREER_IDS(
       HttpStatus.BAD_REQUEST,
       "요청한 career id들 중에 유효하지 않은 값이 존재합니다"

--- a/backend/emm-sale/src/main/resources/http/member.http
+++ b/backend/emm-sale/src/main/resources/http/member.http
@@ -41,3 +41,19 @@ Content-Type: application/json
 {
   "openProfileUrl": "https://open.kakao.com/profile"
 }
+
+### 사용자의 한줄 자기소개 업데이트
+PUT http://localhost:8080/members/description
+Content-Type: application/json
+
+{
+  "description": "안녕하세요 김개발입니다."
+}
+
+### 사용자의 한줄 자기소개 100자 초과 업데이트
+PUT http://localhost:8080/members/description
+Content-Type: application/json
+
+{
+  "description": "안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요!"
+}

--- a/backend/emm-sale/src/test/java/com/emmsale/member/api/MemberApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/member/api/MemberApiTest.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.emmsale.helper.MockMvcTestHelper;
 import com.emmsale.member.application.MemberActivityService;
 import com.emmsale.member.application.MemberUpdateService;
+import com.emmsale.member.application.dto.DescriptionRequest;
 import com.emmsale.member.application.dto.MemberActivityAddRequest;
 import com.emmsale.member.application.dto.MemberActivityDeleteRequest;
 import com.emmsale.member.application.dto.MemberActivityInitialRequest;
@@ -219,5 +220,27 @@ class MemberApiTest extends MockMvcTestHelper {
     result.andExpect(status().isBadRequest())
         .andDo(print())
         .andDo(document("update-open-profile-url", REQUEST_FIELDS));
+  }
+
+  @Test
+  @DisplayName("사용자의 description을 성공적으로 업데이트하면, 200 OK가 반환된다.")
+  void test_updateDescription() throws Exception {
+    // given
+    final String description = "안녕하세요 김개발입니다.";
+    final DescriptionRequest request = new DescriptionRequest(description);
+
+    final RequestFieldsSnippet REQUEST_FIELDS = requestFields(
+        fieldWithPath("description").description("한줄 자기소개(100자 이하여야 함)")
+    );
+
+    // when
+    final ResultActions result = mockMvc.perform(put("/members/description")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(request)));
+
+    // then
+    result.andExpect(status().isNoContent())
+        .andDo(print())
+        .andDo(document("update-description", REQUEST_FIELDS));
   }
 }

--- a/backend/emm-sale/src/test/java/com/emmsale/member/application/MemberUpdateServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/member/application/MemberUpdateServiceTest.java
@@ -1,14 +1,22 @@
 package com.emmsale.member.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.emmsale.helper.ServiceIntegrationTestHelper;
 import com.emmsale.member.MemberFixture;
+import com.emmsale.member.application.dto.DescriptionRequest;
 import com.emmsale.member.application.dto.OpenProfileUrlRequest;
 import com.emmsale.member.domain.Member;
 import com.emmsale.member.domain.MemberRepository;
+import com.emmsale.member.exception.MemberException;
+import com.emmsale.member.exception.MemberExceptionType;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class MemberUpdateServiceTest extends ServiceIntegrationTestHelper {
@@ -34,5 +42,66 @@ class MemberUpdateServiceTest extends ServiceIntegrationTestHelper {
 
     // then
     assertThat(actualMember.getOpenProfileUrl()).isEqualTo(expectOpenProfileUrl);
+  }
+
+  @Nested
+  @DisplayName("한줄 자기소개를 업데이트한다.")
+  class UpdateDescription {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"안녕하세요 김개발입니다.", "   <   짜잔   >  "})
+    @DisplayName("정상적으로 업데이트된다.")
+    void updateDescription_success(String inputDescription) {
+      // given
+      final Member member = memberRepository.save(MemberFixture.memberFixture());
+
+      final String expectDescription = inputDescription;
+      final DescriptionRequest request = new DescriptionRequest(expectDescription);
+
+      // when
+      memberUpdateService.updateDescription(member, request);
+
+      final Member actualMember = memberRepository.findById(member.getId()).get();
+
+      // then
+      assertThat(actualMember.getDescription()).isEqualTo(expectDescription);
+    }
+
+    @Test
+    @DisplayName("한줄 자기소개가 100자를 초과하면 예외를 반환한다.")
+    void updateDescription_fail() {
+      // given
+      final Member member = memberRepository.save(MemberFixture.memberFixture());
+
+      final String invalidDescription = "안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요!";
+      final DescriptionRequest request = new DescriptionRequest(invalidDescription);
+
+      // when
+      final ThrowingCallable actual = () -> memberUpdateService.updateDescription(member, request);
+
+      // then
+      assertThatThrownBy(actual)
+          .isInstanceOf(MemberException.class)
+          .hasMessage(MemberExceptionType.OVER_LENGTH_DESCRIPTION.errorMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "        "})
+    @DisplayName("한줄 자기소개에 공백만 들어오면 빈 문자열로 업데이트한다.")
+    void updateDescription_trim(final String inputDescription) {
+      // given
+      final Member member = memberRepository.save(MemberFixture.memberFixture());
+
+      final String expectDescription = "";
+      final DescriptionRequest request = new DescriptionRequest(inputDescription);
+
+      // when
+      memberUpdateService.updateDescription(member, request);
+
+      final Member actualMember = memberRepository.findById(member.getId()).get();
+
+      // then
+      assertThat(actualMember.getDescription()).isEqualTo(expectDescription);
+    }
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#114

## 📝작업 내용
- Member의 description 컬럼을 not null로 변경하고 기본 값을 빈 문자열("")로 수정해주었습니다.
- 한 줄 자기소개를 수정하는 API를 구현하였습니다.

자세한 기능 명세는 이슈를 참고해주세요.

## 예상 소요 시간 및 실제 소요 시간
3시간/2시간
