### PR TITLE
fix: status로 필터링 시 발생하는 500 오류 해결

### DIFF
--- a/backend/emm-sale/src/main/java/com/emmsale/event/application/EventService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/application/EventService.java
@@ -77,7 +77,6 @@ public class EventService {
 
     final EnumMap<EventStatus, List<Event>> sortAndGroupByStatus
         = groupByEventStatus(nowDate, events, year, month);
-
     return filterEventResponsesByStatus(statusName, sortAndGroupByStatus);
   }
 
@@ -148,10 +147,17 @@ public class EventService {
       final EnumMap<EventStatus, List<Event>> sortAndGroupByEventStatus) {
     if (isExistStatusName(statusName)) {
       EventStatus status = EventStatus.from(statusName);
-      return EventResponse.makeEventResponsesByStatus(status,
-          sortAndGroupByEventStatus.get(status));
+      List<Event> filteredEvents = sortAndGroupByEventStatus.get(status);
+      if (cannotFoundKeyStatus(filteredEvents)) {
+        return List.of();
+      }
+      return EventResponse.makeEventResponsesByStatus(status, filteredEvents);
     }
     return EventResponse.mergeEventResponses(sortAndGroupByEventStatus);
+  }
+
+  private boolean cannotFoundKeyStatus(final List<Event> filteredEvents) {
+    return filteredEvents == null;
   }
 
   private boolean isExistStatusName(final String statusName) {

--- a/backend/emm-sale/src/main/java/com/emmsale/event/application/EventService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/application/EventService.java
@@ -63,7 +63,7 @@ public class EventService {
     return participant.getId();
   }
 
-  private static void validateMemberNotAllowed(final Long memberId, final Member member) {
+  private void validateMemberNotAllowed(final Long memberId, final Member member) {
     if (member.isNotMe(memberId)) {
       throw new EventException(EventExceptionType.FORBIDDEN_PARTICIPATE_EVENT);
     }
@@ -75,9 +75,9 @@ public class EventService {
     validateYearAndMonth(year, month);
     List<Event> events = filterEventsByTag(tagName);
 
-    final EnumMap<EventStatus, List<Event>> sortAndGroupByStatus
+    final EnumMap<EventStatus, List<Event>> eventsForEventStatus
         = groupByEventStatus(nowDate, events, year, month);
-    return filterEventResponsesByStatus(statusName, sortAndGroupByStatus);
+    return filterEventResponsesByStatus(statusName, eventsForEventStatus);
   }
 
   @Transactional(readOnly = true)
@@ -144,16 +144,16 @@ public class EventService {
   }
 
   private List<EventResponse> filterEventResponsesByStatus(final String statusName,
-      final EnumMap<EventStatus, List<Event>> sortAndGroupByEventStatus) {
+      final EnumMap<EventStatus, List<Event>> eventsForEventStatus) {
     if (isExistStatusName(statusName)) {
       EventStatus status = EventStatus.from(statusName);
-      List<Event> filteredEvents = sortAndGroupByEventStatus.get(status);
+      List<Event> filteredEvents = eventsForEventStatus.get(status);
       if (cannotFoundKeyStatus(filteredEvents)) {
         return List.of();
       }
       return EventResponse.makeEventResponsesByStatus(status, filteredEvents);
     }
-    return EventResponse.mergeEventResponses(sortAndGroupByEventStatus);
+    return EventResponse.mergeEventResponses(eventsForEventStatus);
   }
 
   private boolean cannotFoundKeyStatus(final List<Event> filteredEvents) {

--- a/backend/emm-sale/src/main/java/com/emmsale/event/domain/EventStatus.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/domain/EventStatus.java
@@ -26,7 +26,7 @@ public enum EventStatus {
         .orElseThrow(() -> new EventException(INVALID_STATUS));
   }
 
-  public boolean isSameValue(String value) {
+  private boolean isSameValue(String value) {
     return this.value.equals(value);
   }
 }

--- a/backend/emm-sale/src/test/java/com/emmsale/event/domain/EventStatusTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/domain/EventStatusTest.java
@@ -1,0 +1,40 @@
+package com.emmsale.event.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.emmsale.event.exception.EventException;
+import com.emmsale.event.exception.EventExceptionType;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class EventStatusTest {
+
+  @ParameterizedTest
+  @CsvSource(value = {"진행 중,IN_PROGRESS", "진행 예정,UPCOMING", "종료된 행사,ENDED"}, delimiter = ',')
+  @DisplayName("동일한 문자 값을 갖는 EventStatus가 존재하면 해당 enum 객체를 반환한다.")
+  void from_success(String input, EventStatus expected) {
+    // given, when
+    final EventStatus actual = EventStatus.from(input);
+
+    // then
+    assertThat(actual).isEqualTo(expected);
+
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"진행중", "진행예정", "아마란스", "진행 중 "})
+  @DisplayName("동일한 문자 값을 갖는 EventStatus가 존재하지 않으면 예외를 반환한다.")
+  void from_fail(String input) {
+    // given, when
+    final ThrowingCallable actual = () -> EventStatus.from(input);
+
+    // then
+    assertThatThrownBy(actual)
+        .isInstanceOf(EventException.class)
+        .hasMessage(EventExceptionType.INVALID_STATUS.errorMessage());
+  }
+}

--- a/backend/emm-sale/src/test/java/com/emmsale/event/domain/EventTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/domain/EventTest.java
@@ -7,13 +7,29 @@ import com.emmsale.event.EventFixture;
 import com.emmsale.event.exception.EventException;
 import com.emmsale.event.exception.EventExceptionType;
 import com.emmsale.member.domain.Member;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class EventTest {
+
+  @ParameterizedTest
+  @CsvSource(value = {"2023-03-01,UPCOMING", "2023-07-25,IN_PROGRESS",
+      "2023-08-01,ENDED"}, delimiter = ',')
+  @DisplayName("현재 날짜가 주어지면 행사의 진행 상태를 계산한다.")
+  void calculateEventStatus(LocalDate input, EventStatus expected) {
+    // given, when
+    EventStatus actual = EventFixture.AI_컨퍼런스().calculateEventStatus(input);
+
+    // then
+    assertThat(actual).isEqualTo(expected);
+
+  }
 
   @Nested
   class addParticipant {


### PR DESCRIPTION
## #️⃣연관된 이슈
#130

## 📝작업 내용
- 필터링한 EnumMap 객체에 대해 null 체크를 수행하여 NPE가 터지지 않게 하였습니다.

## 예상 소요 시간 및 실제 소요 시간
급하게 작업하느라 측정하지 않았습니다...죄송합니다

