### PR TITLE
Feature/#141-알림 목록 조회 API 구현

### DIFF
--- a/backend/emm-sale/src/docs/asciidoc/index.adoc
+++ b/backend/emm-sale/src/docs/asciidoc/index.adoc
@@ -95,7 +95,6 @@ include::{snippets}/find-profile/http-response.adoc[]
 .HTTP response 설명
 include::{snippets}/find-profile/response-fields.adoc[]
 
-
 == Event
 
 === `GET` : 행사 상세정보 조회
@@ -257,3 +256,13 @@ include::{snippets}/find-notification/response-fields.adoc[]
 .HTTP response
 include::{snippets}/find-notification/http-response.adoc[]
 
+=== `GET` : 사용자가 받은 모든 알림 목록 조회
+
+.HTTP request
+include::{snippets}/find-all-notifications/http-request.adoc[]
+
+.HTTP response 설명
+include::{snippets}/find-all-notifications/response-fields.adoc[]
+
+.HTTP response
+include::{snippets}/find-all-notifications/http-response.adoc[]

--- a/backend/emm-sale/src/docs/asciidoc/index.adoc
+++ b/backend/emm-sale/src/docs/asciidoc/index.adoc
@@ -24,8 +24,6 @@ include::{snippets}/add-activity/response-fields.adoc[]
 
 === `DELETE`: Activity 삭제 API
 
-=== `DELETE`: 커리어 삭제 API
-
 .HTTP request 설명
 include::{snippets}/delete-activity/request-fields.adoc[]
 

--- a/backend/emm-sale/src/main/java/com/emmsale/notification/api/NotificationApi.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/notification/api/NotificationApi.java
@@ -1,11 +1,13 @@
 package com.emmsale.notification.api;
 
+import com.emmsale.member.domain.Member;
 import com.emmsale.notification.application.NotificationCommandService;
 import com.emmsale.notification.application.NotificationQueryService;
 import com.emmsale.notification.application.dto.FcmTokenRequest;
 import com.emmsale.notification.application.dto.NotificationModifyRequest;
 import com.emmsale.notification.application.dto.NotificationRequest;
 import com.emmsale.notification.application.dto.NotificationResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -48,5 +50,11 @@ public class NotificationApi {
       @PathVariable("notification-id") final Long notificationId
   ) {
     return notificationQueryService.findNotificationBy(notificationId);
+  }
+
+  @GetMapping("/notifications")
+  @ResponseStatus(HttpStatus.OK)
+  public List<NotificationResponse> findAll(final Member member) {
+    return notificationCommandService.findAllNotifications(member);
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/notification/application/NotificationCommandService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/notification/application/NotificationCommandService.java
@@ -4,6 +4,7 @@ import static com.emmsale.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
 import static com.emmsale.notification.exception.NotificationExceptionType.BAD_REQUEST_MEMBER_ID;
 import static com.emmsale.notification.exception.NotificationExceptionType.NOT_FOUND_NOTIFICATION;
 
+import com.emmsale.member.domain.Member;
 import com.emmsale.member.domain.MemberRepository;
 import com.emmsale.member.exception.MemberException;
 import com.emmsale.notification.application.dto.FcmTokenRequest;
@@ -16,6 +17,7 @@ import com.emmsale.notification.domain.Notification;
 import com.emmsale.notification.domain.NotificationRepository;
 import com.emmsale.notification.exception.NotificationException;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -94,5 +96,14 @@ public class NotificationCommandService {
         .orElseThrow(() -> new NotificationException(NOT_FOUND_NOTIFICATION));
 
     savedNotification.modifyStatus(notificationModifyRequest.getUpdatedStatus());
+  }
+
+  public List<NotificationResponse> findAllNotifications(final Member member) {
+    final List<Notification> notifications = notificationRepository.findAllByReceiverId(
+        member.getId());
+
+    return notifications.stream()
+        .map(NotificationResponse::from)
+        .collect(Collectors.toList());
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/notification/domain/NotificationRepository.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/notification/domain/NotificationRepository.java
@@ -1,7 +1,9 @@
 package com.emmsale.notification.domain;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
+  List<Notification> findAllByReceiverId(Long memberId);
 }

--- a/backend/emm-sale/src/test/java/com/emmsale/notification/api/NotificationApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/notification/api/NotificationApiTest.java
@@ -24,6 +24,7 @@ import com.emmsale.notification.application.dto.NotificationModifyRequest;
 import com.emmsale.notification.application.dto.NotificationRequest;
 import com.emmsale.notification.application.dto.NotificationResponse;
 import com.emmsale.notification.domain.NotificationStatus;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -183,5 +184,36 @@ class NotificationApiTest extends MockMvcTestHelper {
         .andExpect(status().isOk())
         .andDo(print())
         .andDo(document("find-notification", responseFields, pathParameters));
+  }
+
+  @Test
+  @DisplayName("사용자가 받은 알림의 목록을 성공적으로 반환하면 200 OK를 반환한다.")
+  void test_findAll() throws Exception {
+    //given
+    final String accessToken = "Bearer access_token";
+
+    final long memberId = 1L;
+
+    final List<NotificationResponse> expectResponses = List.of(
+        new NotificationResponse(931L, 3342L, memberId, "같이 가요~", 312L),
+        new NotificationResponse(932L, 1345L, memberId, "소통해요~", 123L)
+    );
+
+    when(notificationCommandService.findAllNotifications(any())).thenReturn(expectResponses);
+
+    final ResponseFieldsSnippet responseFields = responseFields(
+        fieldWithPath("[].notificationId").description("저장된 알림 ID"),
+        fieldWithPath("[].senderId").description("보내는 사람 ID"),
+        fieldWithPath("[].receiverId").description("받는 사람 ID"),
+        fieldWithPath("[].message").description("알림 보낼 때 메시지"),
+        fieldWithPath("[].eventId").description("행사 ID")
+    );
+
+    //when & then
+    mockMvc.perform(get("/notifications")
+            .header("Authorization", accessToken))
+        .andExpect(status().isOk())
+        .andDo(print())
+        .andDo(document("find-all-notifications", responseFields));
   }
 }

--- a/backend/emm-sale/src/test/java/com/emmsale/notification/application/NotificationCommandServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/notification/application/NotificationCommandServiceTest.java
@@ -26,9 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.jdbc.Sql;
 
-@Sql("/data-test.sql")
 class NotificationCommandServiceTest extends ServiceIntegrationTestHelper {
 
   @Autowired

--- a/backend/emm-sale/src/test/resources/data-test.sql
+++ b/backend/emm-sale/src/test/resources/data-test.sql
@@ -7,6 +7,7 @@ truncate table tag;
 truncate table event_tag;
 truncate table member_tag;
 truncate table event_member;
+truncate table notification;
 
 insert into activity(id, type, name)
 values (1, 'CLUB', 'YAPP');


### PR DESCRIPTION
## #️⃣연관된 이슈
- #141

close #141

## 📝작업 내용
알림 목록 조회 api 구현

### 스크린샷 (선택)
![localhost_63342_emm-sale_backend_emm-sale_src_main_resources_static_docs_index html__ijt=ghk47sljcf1olm012e33rbin68 _ij_reload=RELOAD_ON_SAVE](https://github.com/woowacourse-teams/2023-emmsale/assets/71651608/ffdb6004-2654-487c-80fe-e5942c3758ea)

## 예상 소요 시간 및 실제 소요 시간
1시간/1시간