### PR TITLE
refactor: 참가신청 취소하는 API에서 memberId를 queryParam으로 받도록 수정

### DIFF
--- a/backend/emm-sale/src/main/java/com/emmsale/event/api/EventApi.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/api/EventApi.java
@@ -56,10 +56,10 @@ public class EventApi {
   @DeleteMapping("/{eventId}/participants")
   public ResponseEntity<String> cancelParticipateEvent(
       @PathVariable final Long eventId,
-      @RequestBody final EventParticipateRequest request,
+      @RequestParam(name = "member-id") final Long memberId,
       final Member member
   ) {
-    eventService.cancelParticipate(eventId, request.getMemberId(), member);
+    eventService.cancelParticipate(eventId, memberId, member);
 
     return ResponseEntity.noContent().build();
   }

--- a/backend/emm-sale/src/test/java/com/emmsale/event/api/EventApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/api/EventApiTest.java
@@ -127,17 +127,13 @@ class EventApiTest extends MockMvcTestHelper {
     final EventParticipateRequest request = new EventParticipateRequest(memberId);
     final String fakeAccessToken = "Bearer accessToken";
 
-    final RequestFieldsSnippet requestFields = requestFields(
-        fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("멤버 식별자")
-    );
-
     //when
-    mockMvc.perform(delete(format("/events/%s/participants", eventId))
+    mockMvc.perform(delete(format("/events/%s/participants?member-id=%s", eventId, memberId))
             .header("Authorization", fakeAccessToken)
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isNoContent())
-        .andDo(document("participate-event-cancel", requestFields));
+        .andDo(document("participate-event-cancel"));
   }
 
   @Test


### PR DESCRIPTION
## #️⃣연관된 이슈
- #185 

## 📝작업 내용
- 참가신청 취소하는 APi에서 memberId를 쿼리 파람으로 받도록 수정

## 예상 소요 시간 및 실제 소요 시간
- 15분 / 10분