### PR TITLE
Feature/#217-행사 목록 조회 API 필터링 옵션 수정

### DIFF
--- a/backend/emm-sale/src/docs/asciidoc/index.adoc
+++ b/backend/emm-sale/src/docs/asciidoc/index.adoc
@@ -144,7 +144,7 @@ include::{snippets}/participate-event-cancel/request-parameters.adoc[]
 .HTTP response
 include::{snippets}/participate-event-cancel/http-response.adoc[]
 
-=== `GET`: 행사사에 이미 참여한 멤버인지 확인
+=== `GET`: 행사에 이미 참여한 멤버인지 확인
 
 .HTTP request
 include::{snippets}/check-already-participate/http-request.adoc[]

--- a/backend/emm-sale/src/main/java/com/emmsale/event/api/EventApi.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/api/EventApi.java
@@ -9,6 +9,7 @@ import com.emmsale.event.application.dto.EventDetailResponse;
 import com.emmsale.event.application.dto.EventParticipateRequest;
 import com.emmsale.event.application.dto.EventResponse;
 import com.emmsale.event.application.dto.ParticipantResponse;
+import com.emmsale.event.domain.EventStatus;
 import com.emmsale.event.domain.EventType;
 import com.emmsale.member.domain.Member;
 import java.time.LocalDate;
@@ -73,12 +74,12 @@ public class EventApi {
   @GetMapping
   public ResponseEntity<List<EventResponse>> findEvents(
       @RequestParam final EventType category,
-      @RequestParam(required = false) final Integer year,
-      @RequestParam(required = false) final Integer month,
-      @RequestParam(required = false) final String tag,
-      @RequestParam(required = false) final String status) {
+      @RequestParam(name = "start_date", required = false) final String startDate,
+      @RequestParam(name = "end_date", required = false) final String endDate,
+      @RequestParam(required = false) final List<String> tags,
+      @RequestParam(required = false) final List<EventStatus> statuses) {
     return ResponseEntity.ok(
-        eventService.findEvents(category, LocalDate.now(), year, month, tag, status));
+        eventService.findEvents(category, LocalDate.now(), startDate, endDate, tags, statuses));
   }
 
   @PostMapping

--- a/backend/emm-sale/src/main/java/com/emmsale/event/application/EventService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/application/EventService.java
@@ -45,8 +45,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class EventService {
 
-  public static final String MIN_DATE = "2000-01-01";
-  public static final String MAX_DATE = "2999-12-31";
+  private static final String MIN_DATE = "2000-01-01";
+  private static final String MAX_DATE = "2999-12-31";
 
   private final EventRepository eventRepository;
   private final ParticipantRepository participantRepository;

--- a/backend/emm-sale/src/main/java/com/emmsale/event/application/EventService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/application/EventService.java
@@ -51,10 +51,6 @@ public class EventService {
     }
   }
 
-  private static boolean isExistFilterDate(final String startDate, final String endDate) {
-    return startDate != null || endDate != null;
-  }
-
   @Transactional(readOnly = true)
   public EventDetailResponse findEvent(final Long id, final LocalDate today) {
     final Event event = eventRepository.findById(id)
@@ -136,6 +132,10 @@ public class EventService {
     if (tags.size() != tagNames.size()) {
       throw new TagException(NOT_FOUND_TAG);
     }
+  }
+
+  private boolean isExistFilterDate(final String startDate, final String endDate) {
+    return startDate != null || endDate != null;
   }
 
   private List<Event> filterByPeriod(final List<Event> events, final String startDate,

--- a/backend/emm-sale/src/main/java/com/emmsale/event/domain/repository/EventRepository.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/domain/repository/EventRepository.java
@@ -1,15 +1,13 @@
 package com.emmsale.event.domain.repository;
 
 import com.emmsale.event.domain.Event;
-import com.emmsale.event.domain.EventType;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface EventRepository extends JpaRepository<Event, Long> {
-
-  List<Event> findEventsByType(final EventType type);
+public interface EventRepository extends JpaRepository<Event, Long>,
+    JpaSpecificationExecutor<Event> {
 
   boolean existsById(final Long eventId);
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/event/domain/repository/EventSpecification.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/domain/repository/EventSpecification.java
@@ -1,0 +1,39 @@
+package com.emmsale.event.domain.repository;
+
+import com.emmsale.event.domain.Event;
+import com.emmsale.event.domain.EventType;
+import com.emmsale.tag.domain.Tag;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.JoinType;
+import org.springframework.data.jpa.domain.Specification;
+
+public class EventSpecification {
+
+  public static Specification<Event> filterByCategory(final EventType category) {
+    return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("type"), category);
+  }
+
+  public static Specification<Event> filterByTags(final List<String> tags) {
+    return (root, query, criteriaBuilder) -> {
+      query.distinct(true);
+      Join<Event, Tag> joinedTags = root
+          .join("tags", JoinType.INNER)
+          .join("tag", JoinType.INNER);
+      return criteriaBuilder.and(joinedTags.get("name").in(tags));
+    };
+  }
+
+  public static Specification<Event> filterByPeriod(final LocalDateTime startDate,
+      final LocalDateTime endDate) {
+    return (root, query, criteriaBuilder) ->
+        criteriaBuilder.or(
+            criteriaBuilder.between(root.get("startDate"), startDate, endDate),
+            criteriaBuilder.between(root.get("endDate"), startDate, endDate),
+            criteriaBuilder.and(
+                criteriaBuilder.lessThanOrEqualTo(root.get("startDate"), endDate),
+                criteriaBuilder.greaterThanOrEqualTo(root.get("endDate"), startDate))
+        );
+  }
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/event/domain/repository/EventTagRepository.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/domain/repository/EventTagRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EventTagRepository extends JpaRepository<EventTag, Long> {
 
-  List<EventTag> findEventTagsByTag(Tag tag);
+  List<EventTag> findEventTagsByTagIn(List<Tag> tags);
 
   void deleteAllByEventId(Long eventId);
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/event/exception/EventExceptionType.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/exception/EventExceptionType.java
@@ -15,17 +15,9 @@ public enum EventExceptionType implements BaseExceptionType {
       HttpStatus.BAD_REQUEST,
       "요청하신 상태는 유효하지 않는 값입니다."
   ),
-  INVALID_YEAR_AND_MONTH(
+  INVALID_DATE_FORMAT(
       HttpStatus.BAD_REQUEST,
-      "날짜 정보는 연도와 달을 모두 입력해야 합니다."
-  ),
-  INVALID_YEAR(
-      HttpStatus.BAD_REQUEST,
-      "연도 값은 2015 이상이어야 합니다."
-  ),
-  INVALID_MONTH(
-      HttpStatus.BAD_REQUEST,
-      "월은 1에서 12 사이여야 합니다."
+      "날짜 형식이 올바르지 않습니다."
   ),
   NOT_FOUND_TAG(
       HttpStatus.NOT_FOUND,
@@ -34,7 +26,10 @@ public enum EventExceptionType implements BaseExceptionType {
   START_DATE_TIME_AFTER_END_DATE_TIME(
       HttpStatus.BAD_REQUEST,
       "행사의 시작 일시가 종료 일시 이후일 수 없습니다."
-  );
+  ),
+  START_DATE_AFTER_END_DATE(
+      HttpStatus.BAD_REQUEST,
+      "조회하려는 날짜 범위의 시작일이 종료일 이후일 수 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String errorMessage;

--- a/backend/emm-sale/src/main/java/com/emmsale/tag/domain/TagRepository.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/tag/domain/TagRepository.java
@@ -1,9 +1,12 @@
 package com.emmsale.tag.domain;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
+
+  List<Tag> findByNameIn(List<String> tagNames);
 
   Optional<Tag> findByName(String name);
 }

--- a/backend/emm-sale/src/main/resources/http/event.http
+++ b/backend/emm-sale/src/main/resources/http/event.http
@@ -5,22 +5,22 @@ Content-Type: application/json
 
 ### 날짜 필터링이 적용된 경우
 
-GET http://localhost:8080/events?category=CONFERENCE&year=2023&month=7
+GET http://localhost:8080/events?category=CONFERENCE&start_date=2023-09-01
 Content-Type: application/json
 
 ### 상태 필터링이 적용된 경우
 
-GET http://localhost:8080/events?category=CONFERENCE&status=진행 중
+GET http://localhost:8080/events?category=CONFERENCE&statuses=ENDED,IN_PROGRESS
 Content-Type: application/json
 
 ### 태그 필터링이 적용된 경우
 
-GET http://localhost:8080/events?category=CONFERENCE&tag=안드로이드
+GET http://localhost:8080/events?category=CONFERENCE&tags=AI,백엔드
 Content-Type: application/json
 
 ### 태그 필터링과 상태 필터링이 모두 적용된 경우
 
-GET http://localhost:8080/events?category=CONFERENCE&year=2023&month=7&tag=백엔드&status=진행 중
+GET http://localhost:8080/events?category=CONFERENCE&tags=백엔드&statuses=IN_PROGRESS
 Content-Type: application/json
 
 ### Event 상세조회

--- a/backend/emm-sale/src/test/java/com/emmsale/event/api/EventApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/api/EventApiTest.java
@@ -4,6 +4,7 @@ import static java.lang.String.format;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -143,10 +144,12 @@ class EventApiTest extends MockMvcTestHelper {
     // given
     final RequestParametersSnippet requestParameters = requestParameters(
         parameterWithName("category").description("행사 카테고리(CONFERENCE, COMPETITION)"),
-        parameterWithName("start_date").description("필터링하려는 기간의 시작일(option)").optional(),
-        parameterWithName("end_date").description("필터링하려는 기간의 끝일(option)").optional(),
+        parameterWithName("start_date").description("필터링하려는 기간의 시작일(yyyy-mm-dd)(option)")
+            .optional(),
+        parameterWithName("end_date").description("필터링하려는 기간의 끝일(yyyy-mm-dd)(option)").optional(),
         parameterWithName("tags").description("필터링하려는 태그(option)").optional(),
-        parameterWithName("statuses").description("필터링하려는 상태(option)").optional()
+        parameterWithName("statuses").description("필터링하려는 상태(UPCOMING, IN_PROGRESS, ENDED)(option)")
+            .optional()
     );
 
     final ResponseFieldsSnippet responseFields = responseFields(
@@ -274,6 +277,23 @@ class EventApiTest extends MockMvcTestHelper {
 
     //then
     result.andExpect(status().isNoContent()).andDo(print()).andDo(document("delete-event"));
+  }
+
+  @Test
+  @DisplayName("이미 Event에 멤버가 참여헀는지 확인할 수 있다.")
+  void isAlreadyParticipate() throws Exception {
+    //given
+    final Long memberId = 2L;
+    final Long eventId = 3L;
+    given(eventService.isAlreadyParticipate(eventId, memberId)).willReturn(true);
+
+    //when && then
+    mockMvc.perform(
+            get("/events/{eventId}/participants/already-participate?member-id={memberId}"
+                , eventId, memberId)
+        )
+        .andExpect(status().isOk())
+        .andDo(document("check-already-participate"));
   }
 
   @Nested
@@ -444,4 +464,5 @@ class EventApiTest extends MockMvcTestHelper {
       result.andExpect(status().isBadRequest());
     }
   }
+
 }

--- a/backend/emm-sale/src/test/java/com/emmsale/event/application/EventServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/application/EventServiceTest.java
@@ -381,7 +381,6 @@ class EventServiceTest extends ServiceIntegrationTestHelper {
           .isEqualTo(expectedEvents);
     }
 
-    // TODO: 2023-08-06  status 필터링 시 정렬 안깨지는지 확인
     @Test
     @DisplayName("2023년 7월 21일에 2023년 7월 31일 이전에 있는 행사를 조회하면, 해당 기간에 걸쳐있는 모든 행사 목록을 조회할 수 있다.")
     void findEvents_before_2023_7_31() {
@@ -568,6 +567,24 @@ class EventServiceTest extends ServiceIntegrationTestHelper {
       final List<EventResponse> actualEvents = eventService.findEvents(EventType.CONFERENCE, TODAY,
           null, null, null,
           List.of(EventStatus.UPCOMING, IN_PROGRESS));
+
+      // then
+      assertThat(actualEvents)
+          .usingRecursiveComparison()
+          .comparingOnlyFields("name", "status")
+          .isEqualTo(expectedEvents);
+    }
+
+    @Test
+    @DisplayName("9월에 존재하는 진행 예정인 '안드로이드', '백엔드' 태그를 포함하는 행사 목록을 조회할 수 있다.")
+    void findEvents_period_tags_filter() {
+      // given
+      final List<EventResponse> expectedEvents = List.of(모바일_컨퍼런스);
+
+      // when
+      final List<EventResponse> actualEvents = eventService.findEvents(EventType.CONFERENCE, TODAY,
+          "2023-09-01", "2023-09-30", List.of("안드로이드", "백엔드"),
+          List.of(EventStatus.UPCOMING));
 
       // then
       assertThat(actualEvents)

--- a/backend/emm-sale/src/test/java/com/emmsale/event/application/EventServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/application/EventServiceTest.java
@@ -9,15 +9,14 @@ import static com.emmsale.event.EventFixture.모바일_컨퍼런스;
 import static com.emmsale.event.EventFixture.안드로이드_컨퍼런스;
 import static com.emmsale.event.EventFixture.웹_컨퍼런스;
 import static com.emmsale.event.EventFixture.인프콘_2023;
+import static com.emmsale.event.domain.EventStatus.IN_PROGRESS;
 import static com.emmsale.event.exception.EventExceptionType.ALREADY_PARTICIPATED;
 import static com.emmsale.event.exception.EventExceptionType.FORBIDDEN_PARTICIPATE_EVENT;
-import static com.emmsale.event.exception.EventExceptionType.INVALID_MONTH;
-import static com.emmsale.event.exception.EventExceptionType.INVALID_STATUS;
-import static com.emmsale.event.exception.EventExceptionType.INVALID_YEAR;
-import static com.emmsale.event.exception.EventExceptionType.INVALID_YEAR_AND_MONTH;
+import static com.emmsale.event.exception.EventExceptionType.INVALID_DATE_FORMAT;
 import static com.emmsale.event.exception.EventExceptionType.NOT_FOUND_EVENT;
 import static com.emmsale.event.exception.EventExceptionType.NOT_FOUND_PARTICIPANT;
 import static com.emmsale.event.exception.EventExceptionType.NOT_FOUND_TAG;
+import static com.emmsale.event.exception.EventExceptionType.START_DATE_AFTER_END_DATE;
 import static com.emmsale.event.exception.EventExceptionType.START_DATE_TIME_AFTER_END_DATE_TIME;
 import static com.emmsale.member.MemberFixture.memberFixture;
 import static com.emmsale.tag.TagFixture.AI;
@@ -37,6 +36,7 @@ import com.emmsale.event.application.dto.EventDetailResponse;
 import com.emmsale.event.application.dto.EventResponse;
 import com.emmsale.event.application.dto.ParticipantResponse;
 import com.emmsale.event.domain.Event;
+import com.emmsale.event.domain.EventStatus;
 import com.emmsale.event.domain.EventTag;
 import com.emmsale.event.domain.EventType;
 import com.emmsale.event.domain.Participant;
@@ -63,7 +63,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -323,14 +322,14 @@ class EventServiceTest extends ServiceIntegrationTestHelper {
     }
 
     @Test
-    @DisplayName("2023년 7월 21일에 2023년 7월 행사를 조회하면, 해당 연도&월에 걸쳐있는 모든 행사 목록을 조회할 수 있다.")
+    @DisplayName("2023년 7월 21일에 2023년 7월 행사를 조회하면, 해당 기간에 걸쳐있는 모든 행사 목록을 조회할 수 있다.")
     void findEvents_2023_7() {
       // given
       final List<EventResponse> expectedEvents = List.of(인프콘_2023, 웹_컨퍼런스, AI_컨퍼런스, 안드로이드_컨퍼런스);
 
       // when
       final List<EventResponse> actualEvents = eventService.findEvents(EventType.CONFERENCE, TODAY,
-          2023, 7, null, null);
+          "2023-07-01", "2023-07-31", null, null);
 
       // then
       assertThat(actualEvents).usingRecursiveComparison().comparingOnlyFields("name", "status")
@@ -338,14 +337,14 @@ class EventServiceTest extends ServiceIntegrationTestHelper {
     }
 
     @Test
-    @DisplayName("2023년 7월 21일에 2023년 8월 행사를 조회하면, 해당 연도&월에 걸쳐있는 모든 행사 목록을 조회할 수 있다.")
+    @DisplayName("2023년 7월 21일에 2023년 8월 행사를 조회하면, 해당 기간에 걸쳐있는 모든 행사 목록을 조회할 수 있다.")
     void findEvents_2023_8() {
       // given
       final List<EventResponse> expectedEvents = List.of(인프콘_2023, 웹_컨퍼런스, 모바일_컨퍼런스);
 
       // when
       final List<EventResponse> actualEvents = eventService.findEvents(EventType.CONFERENCE, TODAY,
-          2023, 8, null, null);
+          "2023-08-01", "2023-08-31", null, null);
 
       // then
       assertThat(actualEvents).usingRecursiveComparison().comparingOnlyFields("name", "status")
@@ -353,31 +352,62 @@ class EventServiceTest extends ServiceIntegrationTestHelper {
     }
 
     @Test
-    @DisplayName("2023년 7월 21일에 2023년 6월 행사를 조회하면, 해당 연도&월에 걸쳐있는 모든 행사 목록을 조회할 수 있다.")
+    @DisplayName("2023년 7월 21일에 2023년 6월 행사를 조회하면, 해당 기간에 걸쳐있는 모든 행사 목록을 조회할 수 있다.")
     void findEvents_2023_6() {
       // given
       final List<EventResponse> expectedEvents = List.of(인프콘_2023, 안드로이드_컨퍼런스);
 
       // when
       final List<EventResponse> actualEvents = eventService.findEvents(EventType.CONFERENCE, TODAY,
-          2023, 6, null, null);
+          "2023-06-01", "2023-06-30", null, null);
 
       // then
       assertThat(actualEvents).usingRecursiveComparison().comparingOnlyFields("name", "status")
           .isEqualTo(expectedEvents);
     }
 
+    @Test
+    @DisplayName("2023년 7월 21일에 2023년 7월 17일 이후에 있는 행사를 조회하면, 해당 기간에 걸쳐있는 모든 행사 목록을 조회할 수 있다.")
+    void findEvents_after_2023_7_17() {
+      // given
+      final List<EventResponse> expectedEvents = List.of(인프콘_2023, 웹_컨퍼런스, AI_컨퍼런스, 모바일_컨퍼런스);
+
+      // when
+      final List<EventResponse> actualEvents = eventService.findEvents(EventType.CONFERENCE, TODAY,
+          "2023-07-17", null, null, null);
+
+      // then
+      assertThat(actualEvents).usingRecursiveComparison().comparingOnlyFields("name", "status")
+          .isEqualTo(expectedEvents);
+    }
+
+    // TODO: 2023-08-06  status 필터링 시 정렬 안깨지는지 확인
+    @Test
+    @DisplayName("2023년 7월 21일에 2023년 7월 31일 이전에 있는 행사를 조회하면, 해당 기간에 걸쳐있는 모든 행사 목록을 조회할 수 있다.")
+    void findEvents_before_2023_7_31() {
+      // given
+      final List<EventResponse> expectedEvents = List.of(인프콘_2023, 웹_컨퍼런스, AI_컨퍼런스, 안드로이드_컨퍼런스);
+
+      // when
+      final List<EventResponse> actualEvents = eventService.findEvents(EventType.CONFERENCE, TODAY,
+          null, "2023-07-31", null, null);
+
+      // then
+      assertThat(actualEvents).usingRecursiveComparison().comparingOnlyFields("name", "status")
+          .isEqualTo(expectedEvents);
+    }
+
+
     @ParameterizedTest
     @NullSource
-    @ValueSource(strings = "진행 중")
-    @DisplayName("등록된 행사가 없을 경우, status 옵션이 있든 없든 빈 목록을 반환한다.")
-    void findEvents_empty(final String statusName) {
+    @DisplayName("등록된 행사가 없고 status 옵션이 없을 경우 빈 목록을 반환한다.")
+    void findEvents_empty(final List<EventStatus> statusName) {
       // given
       eventRepository.deleteAll();
 
       // when
       final List<EventResponse> actualEvents = eventService.findEvents(EventType.CONFERENCE, TODAY,
-          2023, 12, null,
+          "2023-12-01", "2023-12-31", null,
           statusName);
 
       // then
@@ -389,7 +419,7 @@ class EventServiceTest extends ServiceIntegrationTestHelper {
     void findEvents_2023_12() {
       // given, when
       final List<EventResponse> actualEvents = eventService.findEvents(EventType.CONFERENCE, TODAY,
-          2023, 12, null, null);
+          "2023-12-01", "2023-12-31", null, null);
 
       // then
       assertThat(actualEvents).isEmpty();
@@ -401,7 +431,7 @@ class EventServiceTest extends ServiceIntegrationTestHelper {
     void findEvents_empty_tag_filter() {
       // given, when
       final List<EventResponse> actualEvents = eventService.findEvents(EventType.CONFERENCE, TODAY,
-          2023, 12, "안드로이드",
+          "2023-12-01", "2023-12-31", List.of("안드로이드"),
           null);
 
       // then
@@ -413,64 +443,81 @@ class EventServiceTest extends ServiceIntegrationTestHelper {
     void findEvents_empty_status_filter() {
       // given, when
       final List<EventResponse> actualEvents = eventService.findEvents(EventType.CONFERENCE, TODAY,
-          2023, 12, null,
-          "진행 중");
+          "2023-12-01", "2023-12-31", null,
+          List.of(IN_PROGRESS));
 
       // then
       assertThat(actualEvents).isEmpty();
     }
 
     @ParameterizedTest
-    @CsvSource(value = {":3", "2023:"}, delimiter = ':')
-    @DisplayName("연도와 월 중 하나의 값만 유효하게 들어오면 예외를 반환한다.")
-    void findEvents_month_year_fail(final Integer year, final Integer month) {
+    @ValueSource(strings = {"abcde", "00-0-0", "-1-1-1-1", "2023-02-30"})
+    @DisplayName("유효하지 않은 값이 시작일 정보로 들어오면 예외를 반환한다.")
+    void findEvents_start_date_fail(final String startDate) {
       // given, when
       final ThrowingCallable actual = () -> eventService.findEvents(EventType.CONFERENCE, TODAY,
-          year, month, null, null);
+          startDate, "2023-07-31", null, null);
 
       // then
       assertThatThrownBy(actual)
           .isInstanceOf(EventException.class)
-          .hasMessage(INVALID_YEAR_AND_MONTH.errorMessage());
+          .hasMessage(INVALID_DATE_FORMAT.errorMessage());
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {2014, 0, -1})
-    @DisplayName("유효하지 않은 값이 연도 값으로 들어오면 예외를 반환한다.")
-    void findEvents_year_fail(final int year) {
+    @ValueSource(strings = {"abcde", "00-0-0", "-1-1-1-1", "2023-02-30"})
+    @DisplayName("유효하지 않은 값이 종료일 값으로 들어오면 예외를 반환한다.")
+    void findEvents_end_date_fail(final String endDate) {
       // given, when
       final ThrowingCallable actual = () -> eventService.findEvents(EventType.CONFERENCE, TODAY,
-          year, 7, null, null);
+          "2023-07-01", endDate, null, null);
 
       // then
       assertThatThrownBy(actual)
           .isInstanceOf(EventException.class)
-          .hasMessage(INVALID_YEAR.errorMessage());
+          .hasMessage(INVALID_DATE_FORMAT.errorMessage());
     }
 
-    @ParameterizedTest
-    @ValueSource(ints = {0, -1, 13, 14})
-    @DisplayName("유효하지 않은 값이 월 값으로 들어오면 예외를 반환한다.")
-    void findEvents_month_fail(final int month) {
+    @Test
+    @DisplayName("시작일이 종료일보다 뒤에 있으면 예외를 반환한다.")
+    void findEvents_start_after_end_fail() {
       // given, when
       final ThrowingCallable actual = () -> eventService.findEvents(EventType.CONFERENCE, TODAY,
-          2023, month, null, null);
+          "2023-07-16", "2023-07-15", null, null);
 
       // then
       assertThatThrownBy(actual)
           .isInstanceOf(EventException.class)
-          .hasMessage(INVALID_MONTH.errorMessage());
+          .hasMessage(START_DATE_AFTER_END_DATE.errorMessage());
     }
 
     @Test
     @DisplayName("'안드로이드' 태그를 포함하는 행사 목록을 조회할 수 있다.")
     void findEvents_tag_filter() {
       // given
-      final List<EventResponse> expectedEvents = List.of(인프콘_2023, 안드로이드_컨퍼런스);
+      final List<EventResponse> expectedEvents = List.of(인프콘_2023, 모바일_컨퍼런스, 안드로이드_컨퍼런스);
 
       // when
       final List<EventResponse> actualEvents = eventService.findEvents(EventType.CONFERENCE, TODAY,
-          2023, 7, "안드로이드",
+          null, null, List.of("안드로이드"),
+          null);
+
+      // then
+      assertThat(actualEvents)
+          .usingRecursiveComparison()
+          .comparingOnlyFields("name", "status")
+          .isEqualTo(expectedEvents);
+    }
+
+    @Test
+    @DisplayName("'안드로이드', '백엔드' 태그를 포함하는 행사 목록을 조회할 수 있다.")
+    void findEvents_tags_filter() {
+      // given
+      final List<EventResponse> expectedEvents = List.of(인프콘_2023, 웹_컨퍼런스, 모바일_컨퍼런스, 안드로이드_컨퍼런스);
+
+      // when
+      final List<EventResponse> actualEvents = eventService.findEvents(EventType.CONFERENCE, TODAY,
+          null, null, List.of("안드로이드", "백엔드"),
           null);
 
       // then
@@ -485,7 +532,7 @@ class EventServiceTest extends ServiceIntegrationTestHelper {
     void findEvents_tag_filter_fail() {
       // given, when
       final ThrowingCallable actual = () -> eventService.findEvents(EventType.CONFERENCE, TODAY,
-          2023, 7, "개발", null);
+          null, null, List.of("개발"), null);
 
       // then
       assertThatThrownBy(actual)
@@ -501,8 +548,8 @@ class EventServiceTest extends ServiceIntegrationTestHelper {
 
       // when
       final List<EventResponse> actualEvents = eventService.findEvents(EventType.CONFERENCE, TODAY,
-          2023, 7, null,
-          "진행 중");
+          null, null, null,
+          List.of(IN_PROGRESS));
 
       // then
       assertThat(actualEvents)
@@ -512,17 +559,21 @@ class EventServiceTest extends ServiceIntegrationTestHelper {
     }
 
     @Test
-    @DisplayName("잘못된 양식의 status 가 입력으로 들어오면 예외를 반환한다.")
-    void findEvents_status_filter_fail() {
-      // given, when
-      final ThrowingCallable actual = () -> eventService.findEvents(EventType.CONFERENCE, TODAY,
-          2023, 7, null,
-          "존재하지 않는 상태");
+    @DisplayName("'진행 중' 및 '진행 예정' 상태의 행사 목록을 조회할 수 있다.")
+    void findEvents_statuses_filter() {
+      // given
+      final List<EventResponse> expectedEvents = List.of(인프콘_2023, 웹_컨퍼런스, AI_컨퍼런스, 모바일_컨퍼런스);
+
+      // when
+      final List<EventResponse> actualEvents = eventService.findEvents(EventType.CONFERENCE, TODAY,
+          null, null, null,
+          List.of(EventStatus.UPCOMING, IN_PROGRESS));
 
       // then
-      assertThatThrownBy(actual)
-          .isInstanceOf(EventException.class)
-          .hasMessage(INVALID_STATUS.errorMessage());
+      assertThat(actualEvents)
+          .usingRecursiveComparison()
+          .comparingOnlyFields("name", "status")
+          .isEqualTo(expectedEvents);
     }
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#217

## 📝작업 내용
- 진행 상황을 EventStatus의 리스트로 받아오고 필터 조건을 OR로 계산.
- 태그를 리스트로 받아오고 필터 조건을 OR로 계산.
- 날짜를 year, month 대신 startDate, endDate로 받고, 연/월 뿐만 아니라 일을 포함하게 함
- startDate만 입력하는 경우, 해당 일 이후의 행사들을 조회
- endDate만 입력하는 경우, 해당 일 이전의 행사들을 조회

## 예상 소요 시간 및 실제 소요 시간
4시간/3시간


## 💬리뷰 요구사항(선택)
혹시나 누락된 테스트가 보이거나, 추가적으로 검증했으면 좋겠다 싶은 로직이 있으면 코멘트 부탁드립니다.