### PR TITLE
Fix/#223 이벤트 상세 조회 시 상태 잘못 계산하는 오류 수정

### DIFF
--- a/backend/emm-sale/src/main/java/com/emmsale/event/application/dto/EventDetailResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/application/dto/EventDetailResponse.java
@@ -47,24 +47,11 @@ public class EventDetailResponse {
         event.getStartDate(),
         event.getEndDate(),
         event.getLocation(),
-        calculateStatus(event.getStartDate(), event.getEndDate()),
+        event.calculateEventStatus(today).getValue(),
         tagNames,
         event.getImageUrl(),
         event.calculateRemainingDays(today),
         event.getType().toString()
     );
-  }
-
-  private static String calculateStatus(
-      final LocalDateTime startDate,
-      final LocalDateTime endDate
-  ) {
-    final LocalDateTime now = LocalDateTime.now();
-    if (startDate.isBefore(now)) {
-      return EXPECTED;
-    } else if (endDate.isBefore(now)) {
-      return IN_PROGRESS;
-    }
-    return END;
   }
 }

--- a/backend/emm-sale/src/test/java/com/emmsale/event/application/dto/EventDetailResponseTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/application/dto/EventDetailResponseTest.java
@@ -1,0 +1,43 @@
+package com.emmsale.event.application.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.emmsale.event.EventFixture;
+import com.emmsale.event.domain.Event;
+import com.emmsale.event.domain.EventStatus;
+import java.time.LocalDate;
+import java.util.Collections;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class EventDetailResponseTest {
+
+  @Test
+  @DisplayName("이벤트를 상세 조회할 값을 변환할 수 있다.")
+  void createEventDetailResponseTest() {
+    //given
+    final Event 구름톤 = EventFixture.구름톤();
+    final LocalDate 날짜 = LocalDate.of(2023, 7, 1);
+    final EventDetailResponse expected = new EventDetailResponse(
+        구름톤.getId(),
+        구름톤.getName(),
+        구름톤.getInformationUrl(),
+        구름톤.getStartDate(),
+        구름톤.getEndDate(),
+        구름톤.getLocation(),
+        EventStatus.UPCOMING.getValue(),
+        Collections.emptyList(),
+        구름톤.getImageUrl(),
+        2,
+        구름톤.getType().toString()
+    );
+
+    //when
+    final EventDetailResponse actual = EventDetailResponse.from(구름톤, 날짜);
+
+    //then
+    assertThat(actual)
+        .usingRecursiveComparison()
+        .isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- #223 

## 📝작업 내용
- 이벤트 상세 조회 시 상태를 잘못 계산하는 오류 수정

## 예상 소요 시간 및 실제 소요 시간
- 30분