### PR TITLE
Fix/#232 프로필에 동일한 활동을 중복해서 등록할 수 있는 버그

### DIFF
--- a/backend/emm-sale/src/main/java/com/emmsale/member/application/MemberActivityService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/application/MemberActivityService.java
@@ -13,6 +13,7 @@ import com.emmsale.member.domain.MemberActivityRepository;
 import com.emmsale.member.domain.MemberRepository;
 import com.emmsale.member.exception.MemberException;
 import com.emmsale.member.exception.MemberExceptionType;
+import java.util.HashSet;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -66,8 +67,10 @@ public class MemberActivityService {
   ) {
     final List<Long> activityIds = memberActivityAddRequest.getActivityIds();
     final List<MemberActivity> memberActivities = memberActivityRepository.findAllByMember(member);
-    if (isAlreadyExistActivity(memberActivities, activityIds) || hasDuplicateId(memberActivities,
-        activityIds)) {
+    if (hasDuplicateId(memberActivities, activityIds)) {
+      throw new MemberException(MemberExceptionType.DUPLICATE_ACTIVITY);
+    }
+    if (isAlreadyExistActivity(memberActivities, activityIds)) {
       throw new MemberException(MemberExceptionType.ALREADY_EXIST_ACTIVITY);
     }
     saveMemberActivities(member, activityIds);
@@ -86,7 +89,7 @@ public class MemberActivityService {
 
   private boolean hasDuplicateId(final List<MemberActivity> memberActivities,
       final List<Long> activityIds) {
-    return activityIds.stream().distinct().count() != memberActivities.size();
+    return new HashSet<>(activityIds).size() != memberActivities.size();
   }
 
   public List<MemberActivityResponses> deleteActivity(

--- a/backend/emm-sale/src/main/java/com/emmsale/member/exception/MemberExceptionType.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/exception/MemberExceptionType.java
@@ -22,7 +22,7 @@ public enum MemberExceptionType implements BaseExceptionType {
 
   ALREADY_EXIST_ACTIVITY(
       HttpStatus.BAD_REQUEST,
-      "요청한 activity id는 이미 존재합니다."
+      "이미 등록된 활동입니다."
   ),
 
   NULL_DESCRIPTION(

--- a/backend/emm-sale/src/main/java/com/emmsale/member/exception/MemberExceptionType.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/exception/MemberExceptionType.java
@@ -14,6 +14,12 @@ public enum MemberExceptionType implements BaseExceptionType {
       HttpStatus.BAD_REQUEST,
       "요청한 activity id들 중에 유효하지 않은 값이 존재합니다"
   ),
+
+  ALREADY_EXIST_ACTIVITY(
+      HttpStatus.BAD_REQUEST,
+      "요청한 activity id는 이미 존재합니다."
+  ),
+
   NULL_DESCRIPTION(
       HttpStatus.BAD_REQUEST,
       "한 줄 자기소개는 null이 될 수 없습니다."

--- a/backend/emm-sale/src/main/java/com/emmsale/member/exception/MemberExceptionType.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/exception/MemberExceptionType.java
@@ -10,6 +10,11 @@ public enum MemberExceptionType implements BaseExceptionType {
       "해당 멤버는 존재하지 않습니다."
   ),
 
+  ALREADY_ONBOARDING(
+      HttpStatus.BAD_REQUEST,
+      "이미 온보딩을 완료한 사용자입니다."
+  ),
+
   INVALID_ACTIVITY_IDS(
       HttpStatus.BAD_REQUEST,
       "요청한 activity id들 중에 유효하지 않은 값이 존재합니다"

--- a/backend/emm-sale/src/main/java/com/emmsale/member/exception/MemberExceptionType.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/exception/MemberExceptionType.java
@@ -25,6 +25,11 @@ public enum MemberExceptionType implements BaseExceptionType {
       "이미 등록된 활동입니다."
   ),
 
+  DUPLICATE_ACTIVITY(
+      HttpStatus.BAD_REQUEST,
+      "요청에 중복된 활동 ID가 포함되어 있습니다."
+  ),
+
   NULL_DESCRIPTION(
       HttpStatus.BAD_REQUEST,
       "한 줄 자기소개는 null이 될 수 없습니다."

--- a/backend/emm-sale/src/test/java/com/emmsale/member/application/MemberActivityServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/member/application/MemberActivityServiceTest.java
@@ -34,7 +34,7 @@ class MemberActivityServiceTest extends ServiceIntegrationTestHelper {
   @DisplayName("Activity의 id를 통해서, 사용자의 Activity를 등록하고 사용자의 이름을 수정할 수 있다.")
   void registerActivities() throws Exception {
     //given
-    final List<Long> activityIds = List.of(1L, 2L, 3L, 4L);
+    final List<Long> activityIds = List.of(1L, 2L, 3L);
     final long savedMemberId = 1L;
 
     final Member member = memberRepository.findById(savedMemberId).get();
@@ -154,7 +154,7 @@ class MemberActivityServiceTest extends ServiceIntegrationTestHelper {
     // when, then
     assertThatThrownBy(() -> memberActivityService.addActivity(savedMember, request))
         .isInstanceOf(MemberException.class)
-        .hasMessage(MemberExceptionType.ALREADY_EXIST_ACTIVITY.errorMessage());
+        .hasMessage(MemberExceptionType.DUPLICATE_ACTIVITY.errorMessage());
   }
 
   @Test

--- a/backend/emm-sale/src/test/java/com/emmsale/member/application/MemberActivityServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/member/application/MemberActivityServiceTest.java
@@ -108,7 +108,6 @@ class MemberActivityServiceTest extends ServiceIntegrationTestHelper {
 
     //when
     final List<MemberActivityResponses> actual = memberActivityService.addActivity(member, request);
-
     //then
     assertThat(expected)
         .usingRecursiveComparison()
@@ -121,7 +120,7 @@ class MemberActivityServiceTest extends ServiceIntegrationTestHelper {
   void test_addActivity_invalid_activity_ids_Exception() throws Exception {
     //given
     final Member savedMember = memberRepository.findById(1L).get();
-    final List<Long> activityIds = List.of(1L, 2L, 7L);
+    final List<Long> activityIds = List.of(4L, 5L, 7L);
     final MemberActivityAddRequest request = new MemberActivityAddRequest(activityIds);
 
     //when & then
@@ -138,10 +137,7 @@ class MemberActivityServiceTest extends ServiceIntegrationTestHelper {
     final List<Long> activityIds = List.of(1L, 2L, 7L);
     final MemberActivityAddRequest request = new MemberActivityAddRequest(activityIds);
 
-    // when
-    memberActivityService.addActivity(savedMember, request);
-
-    // then
+    // when, then
     assertThatThrownBy(() -> memberActivityService.addActivity(savedMember, request))
         .isInstanceOf(MemberException.class)
         .hasMessage(MemberExceptionType.ALREADY_EXIST_ACTIVITY.errorMessage());
@@ -152,7 +148,7 @@ class MemberActivityServiceTest extends ServiceIntegrationTestHelper {
   void test_addActivity_ALREADY_EXIST_ACTIVITY_Exception_duplicate_input() throws Exception {
     //given
     final Member savedMember = memberRepository.findById(1L).get();
-    final List<Long> activityIds = List.of(1L, 2L, 1L);
+    final List<Long> activityIds = List.of(4L, 4L, 5L);
     final MemberActivityAddRequest request = new MemberActivityAddRequest(activityIds);
 
     // when, then

--- a/backend/emm-sale/src/test/java/com/emmsale/member/application/MemberQueryServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/member/application/MemberQueryServiceTest.java
@@ -24,7 +24,7 @@ class MemberQueryServiceTest extends ServiceIntegrationTestHelper {
   @DisplayName("사용자를 조회하고 조회 결과를 반환한다.")
   void findOrCreateMemberTest() {
     //given
-    final MemberQueryResponse expectResponse = new MemberQueryResponse(1L, true);
+    final MemberQueryResponse expectResponse = new MemberQueryResponse(1L, false);
 
     final GithubProfileResponse githubProfileFromGithub = new GithubProfileResponse("1", "name",
         "username", "https://imageUrl.com");
@@ -67,7 +67,7 @@ class MemberQueryServiceTest extends ServiceIntegrationTestHelper {
     void findProfile_success() {
       //given
       final Long memberId = 1L;
-      final MemberProfileResponse expectResponse = new MemberProfileResponse(memberId, "member1",
+      final MemberProfileResponse expectResponse = new MemberProfileResponse(memberId, null,
           "", "https://imageurl.com");
 
       //when

--- a/backend/emm-sale/src/test/resources/data-test.sql
+++ b/backend/emm-sale/src/test/resources/data-test.sql
@@ -28,7 +28,7 @@ insert into activity(id, type, name)
 values (6, 'JOB', 'Backend');
 
 insert into member(id, name, image_url, open_profile_url, github_id, created_at, updated_at)
-values (1, 'member1', 'https://imageurl.com', 'https://openprofileurl.com', 1, CURRENT_TIMESTAMP(),
+values (1, null, 'https://imageurl.com', 'https://openprofileurl.com', 1, CURRENT_TIMESTAMP(),
         CURRENT_TIMESTAMP());
 
 insert into member(id, name, image_url, open_profile_url, github_id, created_at, updated_at)


### PR DESCRIPTION
## #️⃣연관된 이슈
#232

## 📝작업 내용
프로필에 동일한 활동을 중복해서 등록할 수 없도록 유효성 검증 코드를 추가하였습니다.

## 예상 소요 시간 및 실제 소요 시간
30분/2시간

## 💬리뷰 요구사항(선택)
온보딩된 사용자가 한 번 더 온보딩 API를 호출하는 것을 막아야 해서 테스트를 위해 test-data.sql에서 insert해준 member의 name을 null로 수정했습니다.