### PR TITLE
Feature/#253 함께해요 게시글 목록 조회 구현

### DIFF
--- a/backend/emm-sale/src/docs/asciidoc/index.adoc
+++ b/backend/emm-sale/src/docs/asciidoc/index.adoc
@@ -125,7 +125,10 @@ include::{snippets}/find-event/http-response.adoc[]
 .HTTP response 설명
 include::{snippets}/find-event/response-fields.adoc[]
 
-=== `POST` : 행사에 함께가기 요청(행사에 함께 가는 멤버에 등록)
+=== `POST` : 행사의 함께 해요 목록에 게시글 추가
+
+.HTTP request 설명
+include::{snippets}/participate-event/request-fields.adoc[]
 
 .HTTP request
 include::{snippets}/participate-event/http-request.adoc[]

--- a/backend/emm-sale/src/main/java/com/emmsale/event/api/EventApi.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/api/EventApi.java
@@ -46,7 +46,7 @@ public class EventApi {
       @RequestBody final EventParticipateRequest request,
       final Member member
   ) {
-    final Long participantId = eventService.participate(eventId, request.getMemberId(), member);
+    final Long participantId = eventService.participate(eventId, request, member);
 
     return ResponseEntity
         .created(create(format("/events/%s/participants/%s", eventId, participantId)))

--- a/backend/emm-sale/src/main/java/com/emmsale/event/application/dto/EventCancelParticipateRequest.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/application/dto/EventCancelParticipateRequest.java
@@ -5,8 +5,11 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
-public class EventParticipateRequest {
+public class EventCancelParticipateRequest {
 
   private final Long memberId;
-  private final String content;
+
+  private EventCancelParticipateRequest() {
+    this(null);
+  }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/event/application/dto/ParticipantResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/application/dto/ParticipantResponse.java
@@ -14,10 +14,17 @@ public class ParticipantResponse {
   private final String name;
   private final String imageUrl;
   private final String description;
+  private final String content;
 
   public static ParticipantResponse from(final Participant participant) {
     final Member member = participant.getMember();
-    return new ParticipantResponse(participant.getId(), member.getId(), member.getName(),
-        member.getImageUrl(), member.getDescription());
+    return new ParticipantResponse(
+        participant.getId(),
+        member.getId(),
+        member.getName(),
+        member.getImageUrl(),
+        member.getDescription(),
+        participant.getContent()
+    );
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/event/application/dto/ParticipantResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/application/dto/ParticipantResponse.java
@@ -2,6 +2,8 @@ package com.emmsale.event.application.dto;
 
 import com.emmsale.event.domain.Participant;
 import com.emmsale.member.domain.Member;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -15,6 +17,10 @@ public class ParticipantResponse {
   private final String imageUrl;
   private final String description;
   private final String content;
+  @JsonFormat(pattern = "yyyy.MM.dd")
+  private final LocalDate createdAt;
+  @JsonFormat(pattern = "yyyy.MM.dd")
+  private final LocalDate updatedAt;
 
   public static ParticipantResponse from(final Participant participant) {
     final Member member = participant.getMember();
@@ -24,7 +30,9 @@ public class ParticipantResponse {
         member.getName(),
         member.getImageUrl(),
         member.getDescription(),
-        participant.getContent()
+        participant.getContent(),
+        participant.getCreatedAt().toLocalDate(),
+        participant.getUpdatedAt().toLocalDate()
     );
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/event/domain/Event.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/domain/Event.java
@@ -53,7 +53,7 @@ public class Event extends BaseEntity {
   private List<EventTag> tags = new ArrayList<>();
   @OneToMany(mappedBy = "event")
   private List<Comment> comments;
-  @OneToMany(mappedBy = "event", cascade = CascadeType.ALL)
+  @OneToMany(mappedBy = "event", cascade = CascadeType.PERSIST)
   private List<Participant> participants = new ArrayList<>();
 
   public Event(
@@ -76,12 +76,13 @@ public class Event extends BaseEntity {
     this.imageUrl = imageUrl;
   }
 
-  public Participant addParticipant(final Member member) {
-    final Participant participant = new Participant(member, this);
+  public Participant addParticipant(final Member member, final String content) {
+    final Participant participant = new Participant(member, this, content);
     participants.add(participant);
     return participant;
   }
 
+  // 요거 이전에 발견하지 못했었는데 나중에 반환값 void로 바꿔도 될까요? 반환하는 값을 쓰지 않는 것 같아서요.
   public List<EventTag> addAllEventTags(final List<Tag> tags) {
     final List<EventTag> eventTags = tags.stream()
         .map(tag -> new EventTag(this, tag))

--- a/backend/emm-sale/src/main/java/com/emmsale/event/domain/Participant.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/domain/Participant.java
@@ -30,10 +30,13 @@ public class Participant {
   @JoinColumn(nullable = false)
   private Event event;
 
-  public Participant(final Member member, final Event event) {
+  private String content;
+
+  public Participant(final Member member, final Event event, final String content) {
     event.validateAlreadyParticipate(member);
     this.member = member;
     this.event = event;
+    this.content = content;
   }
 
   public boolean isSameMember(final Member member) {

--- a/backend/emm-sale/src/main/java/com/emmsale/event/domain/Participant.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/domain/Participant.java
@@ -1,6 +1,7 @@
 package com.emmsale.event.domain;
 
 import com.emmsale.member.domain.Member;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -30,6 +31,7 @@ public class Participant {
   @JoinColumn(nullable = false)
   private Event event;
 
+  @Column(nullable = false)
   private String content;
 
   public Participant(final Member member, final Event event, final String content) {

--- a/backend/emm-sale/src/main/java/com/emmsale/event/domain/Participant.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/domain/Participant.java
@@ -1,5 +1,6 @@
 package com.emmsale.event.domain;
 
+import com.emmsale.base.BaseEntity;
 import com.emmsale.member.domain.Member;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -17,7 +18,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "event_member")
-public class Participant {
+public class Participant extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/emm-sale/src/main/resources/data.sql
+++ b/backend/emm-sale/src/main/resources/data.sql
@@ -183,10 +183,10 @@ values (20, 11, 7);
 insert into event_tag(id, event_id, tag_id)
 values (21, 12, 7);
 
-insert into event_member (member_id, event_id) value (1, 1);
-insert into event_member (member_id, event_id) value (2, 1);
-insert into event_member (member_id, event_id) value (3, 1);
+insert into event_member (member_id, event_id, content) value (1, 1, '빈 게시글 내용');
+insert into event_member (member_id, event_id, content) value (2, 1, '빈 게시글 내용');
+insert into event_member (member_id, event_id, content) value (3, 1, '빈 게시글 내용');
 
-insert into event_member (member_id, event_id) value (1, 2);
-insert into event_member (member_id, event_id) value (2, 2);
-insert into event_member (member_id, event_id) value (3, 2);
+insert into event_member (member_id, event_id, content) value (1, 2, '빈 게시글 내용');
+insert into event_member (member_id, event_id, content) value (2, 2, '빈 게시글 내용');
+insert into event_member (member_id, event_id, content) value (3, 2, '빈 게시글 내용');

--- a/backend/emm-sale/src/main/resources/http/event.http
+++ b/backend/emm-sale/src/main/resources/http/event.http
@@ -26,13 +26,14 @@ Content-Type: application/json
 ### Event 상세조회
 GET http://localhost:8080/events/1
 
-### Event 참여자 목록에 멤버 추가
+### 함께 해요 목록에 게시글 추가
 POST http://localhost:8080/events/1/participants
 Content-Type: application/json
 Authorization: bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjkwMTk2OTY5LCJleHAiOjE2OTM3OTY5Njl9.yahaEBvKBA7xelNuykx8TROhemnzJAsu1Sv5rrSfCM0
 
 {
-  "memberId": 1
+  "memberId": 1,
+  "content": "함께 해요 게시글의 내용"
 }
 
 ### Event 참여자 목록에서 멤버 삭제

--- a/backend/emm-sale/src/main/resources/schema.sql
+++ b/backend/emm-sale/src/main/resources/schema.sql
@@ -22,11 +22,11 @@ create table event
     id              bigint auto_increment primary key,
     created_at      datetime(6),
     updated_at      datetime(6),
-    end_date        datetime(6) not null,
+    end_date        datetime(6)  not null,
     information_url varchar(255) not null,
     location        varchar(255) not null,
     name            varchar(255) not null,
-    start_date      datetime(6) not null,
+    start_date      datetime(6)  not null,
     image_url       varchar(255),
     type            varchar(20)  not null
 );
@@ -89,8 +89,9 @@ create table member_tag
 create table event_member
 (
     id        bigint auto_increment primary key,
-    member_id bigint not null,
-    event_id  bigint not null
+    member_id bigint       not null,
+    event_id  bigint       not null,
+    content   varchar(255) not null
 );
 create table notification
 (

--- a/backend/emm-sale/src/main/resources/schema.sql
+++ b/backend/emm-sale/src/main/resources/schema.sql
@@ -88,10 +88,12 @@ create table member_tag
 
 create table event_member
 (
-    id        bigint auto_increment primary key,
-    member_id bigint       not null,
-    event_id  bigint       not null,
-    content   varchar(255) not null
+    id         bigint auto_increment primary key,
+    created_at datetime(6),
+    updated_at datetime(6),
+    member_id  bigint       not null,
+    event_id   bigint       not null,
+    content    varchar(255) not null
 );
 create table notification
 (
@@ -111,3 +113,10 @@ create table fcm_token
     token     varchar(255) not null,
     member_id bigint       not null unique
 );
+
+/*
+ 2023-08-08 02:40
+ alter table event_member add column content varchar(255) not null;
+ alter table event_member add column created_at datetime(6);
+ alter table event_member add column updated_at datetime(6;
+ */

--- a/backend/emm-sale/src/main/resources/schema.sql
+++ b/backend/emm-sale/src/main/resources/schema.sql
@@ -88,12 +88,9 @@ create table member_tag
 
 create table event_member
 (
-    id         bigint auto_increment primary key,
-    created_at datetime(6),
-    updated_at datetime(6),
-    member_id  bigint       not null,
-    event_id   bigint       not null,
-    content    varchar(255) not null
+    id        bigint auto_increment primary key,
+    member_id bigint not null,
+    event_id  bigint not null
 );
 create table notification
 (
@@ -114,9 +111,10 @@ create table fcm_token
     member_id bigint       not null unique
 );
 
-/*
- 2023-08-08 02:40
- alter table event_member add column content varchar(255) not null;
- alter table event_member add column created_at datetime(6);
- alter table event_member add column updated_at datetime(6;
- */
+-- 2023-08-08 02:40
+alter table event_member
+    add column content varchar(255) not null;
+alter table event_member
+    add column created_at datetime(6);
+alter table event_member
+    add column updated_at datetime(6);

--- a/backend/emm-sale/src/test/java/com/emmsale/event/EventFixture.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/EventFixture.java
@@ -1,7 +1,9 @@
 package com.emmsale.event;
 
+import com.emmsale.event.application.dto.EventParticipateRequest;
 import com.emmsale.event.domain.Event;
 import com.emmsale.event.domain.EventType;
+import com.emmsale.member.domain.Member;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -68,8 +70,11 @@ public class EventFixture {
     );
   }
 
-
   public static LocalDate 날짜_8월_10일() {
     return LocalDate.of(2023, 8, 10);
+  }
+
+  public static EventParticipateRequest createEventParticipateRequest(final Member member){
+    return new EventParticipateRequest(member.getId(), "같이 가요 요청 글");
   }
 }

--- a/backend/emm-sale/src/test/java/com/emmsale/event/api/EventApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/api/EventApiTest.java
@@ -23,6 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.emmsale.event.EventFixture;
 import com.emmsale.event.application.EventService;
+import com.emmsale.event.application.dto.EventCancelParticipateRequest;
 import com.emmsale.event.application.dto.EventDetailRequest;
 import com.emmsale.event.application.dto.EventDetailResponse;
 import com.emmsale.event.application.dto.EventParticipateRequest;
@@ -100,11 +101,14 @@ class EventApiTest extends MockMvcTestHelper {
     final Long eventId = 1L;
     final Long memberId = 2L;
     final Long participantId = 3L;
-    final EventParticipateRequest request = new EventParticipateRequest(memberId);
+    final String content = "함께 해요 게시글의 내용";
+    final EventParticipateRequest request = new EventParticipateRequest(memberId, content);
     final String fakeAccessToken = "Bearer accessToken";
 
     final RequestFieldsSnippet requestFields = requestFields(
-        fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("멤버 식별자"));
+        fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("멤버 식별자"),
+        fieldWithPath("content").type(JsonFieldType.STRING).description("함께 해요 게시글의 내용")
+    );
 
     when(eventService.participate(any(), any(), any())).thenReturn(participantId);
 
@@ -124,7 +128,7 @@ class EventApiTest extends MockMvcTestHelper {
     //given
     final Long eventId = 1L;
     final Long memberId = 2L;
-    final EventParticipateRequest request = new EventParticipateRequest(memberId);
+    final EventCancelParticipateRequest request = new EventCancelParticipateRequest(memberId);
     final String fakeAccessToken = "Bearer accessToken";
 
     final RequestParametersSnippet requestParameters = requestParameters(

--- a/backend/emm-sale/src/test/java/com/emmsale/event/api/EventApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/api/EventApiTest.java
@@ -214,10 +214,13 @@ class EventApiTest extends MockMvcTestHelper {
         fieldWithPath("[].memberId").type(JsonFieldType.NUMBER).description("member의 식별자"),
         fieldWithPath("[].name").type(JsonFieldType.STRING).description("member 이름"),
         fieldWithPath("[].imageUrl").type(JsonFieldType.STRING).description("프로필 이미지 url"),
-        fieldWithPath("[].description").type(JsonFieldType.STRING).description("한줄 자기 소개"));
+        fieldWithPath("[].description").type(JsonFieldType.STRING).description("한줄 자기 소개"),
+        fieldWithPath("[].content").type(JsonFieldType.STRING).description("함께해요 게시글 내용")
+    );
     final List<ParticipantResponse> responses = List.of(
-        new ParticipantResponse(1L, 1L, "스캇", "imageUrl", "토마토 던지는 사람"),
-        new ParticipantResponse(2L, 2L, "홍실", "imageUrl", "토마토 맞는 사람"));
+        new ParticipantResponse(1L, 1L, "스캇", "imageUrl", "토마토 던지는 사람", "저랑 같이 컨퍼런스 갈 사람"),
+        new ParticipantResponse(2L, 2L, "홍실", "imageUrl", "토마토 맞는 사람", "스캇 말고 저랑 갈 사람")
+    );
 
     when(eventService.findParticipants(eventId)).thenReturn(responses);
 

--- a/backend/emm-sale/src/test/java/com/emmsale/event/api/EventApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/api/EventApiTest.java
@@ -215,11 +215,15 @@ class EventApiTest extends MockMvcTestHelper {
         fieldWithPath("[].name").type(JsonFieldType.STRING).description("member 이름"),
         fieldWithPath("[].imageUrl").type(JsonFieldType.STRING).description("프로필 이미지 url"),
         fieldWithPath("[].description").type(JsonFieldType.STRING).description("한줄 자기 소개"),
-        fieldWithPath("[].content").type(JsonFieldType.STRING).description("함께해요 게시글 내용")
+        fieldWithPath("[].content").type(JsonFieldType.STRING).description("함께해요 게시글 내용"),
+        fieldWithPath("[].createdAt").type(JsonFieldType.STRING).description("함께해요 게시글 작성 날짜"),
+        fieldWithPath("[].updatedAt").type(JsonFieldType.STRING).description("함께해요 게시글 수정 날짜")
     );
     final List<ParticipantResponse> responses = List.of(
-        new ParticipantResponse(1L, 1L, "스캇", "imageUrl", "토마토 던지는 사람", "저랑 같이 컨퍼런스 갈 사람"),
-        new ParticipantResponse(2L, 2L, "홍실", "imageUrl", "토마토 맞는 사람", "스캇 말고 저랑 갈 사람")
+        new ParticipantResponse(1L, 1L, "스캇", "imageUrl", "토마토 던지는 사람", "저랑 같이 컨퍼런스 갈 사람",
+            LocalDate.of(2023, 7, 15), LocalDate.of(2023, 7, 15)),
+        new ParticipantResponse(2L, 2L, "홍실", "imageUrl", "토마토 맞는 사람", "스캇 말고 저랑 갈 사람",
+            LocalDate.of(2023, 7, 22), LocalDate.of(2023, 7, 22))
     );
 
     when(eventService.findParticipants(eventId)).thenReturn(responses);

--- a/backend/emm-sale/src/test/java/com/emmsale/event/api/EventApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/api/EventApiTest.java
@@ -107,7 +107,8 @@ class EventApiTest extends MockMvcTestHelper {
 
     final RequestFieldsSnippet requestFields = requestFields(
         fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("멤버 식별자"),
-        fieldWithPath("content").type(JsonFieldType.STRING).description("함께 해요 게시글의 내용")
+        fieldWithPath("content").type(JsonFieldType.STRING)
+            .description("함께 해요 게시글의 내용(공백 불가, 255자 최대)")
     );
 
     when(eventService.participate(any(), any(), any())).thenReturn(participantId);

--- a/backend/emm-sale/src/test/java/com/emmsale/event/application/EventServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/application/EventServiceTest.java
@@ -128,27 +128,29 @@ class EventServiceTest extends ServiceIntegrationTestHelper {
   }
 
   @Test
-  @DisplayName("event의 id로 참여자 목록을 조회할 수 있다.")
+  @DisplayName("event의 id로 참가 게시글 목록을 조회할 수 있다.")
   void findParticipants() {
     // given
     final Event 인프콘 = eventRepository.save(eventFixture());
     final Member 멤버1 = memberRepository.save(new Member(123L, "image1.com"));
     final Member 멤버2 = memberRepository.save(new Member(124L, "image2.com"));
 
-    final Long 멤버1_참가글_ID = eventService.participate(인프콘.getId(),
-        createEventParticipateRequest(멤버1), 멤버1);
-    final Long 멤버2_참가글_ID = eventService.participate(인프콘.getId(),
-        createEventParticipateRequest(멤버2), 멤버2);
+    final EventParticipateRequest requestMember1 = createEventParticipateRequest(멤버1);
+    final EventParticipateRequest requestMember2 = createEventParticipateRequest(멤버2);
+
+    final Long 멤버1_참가글_ID = eventService.participate(인프콘.getId(), requestMember1, 멤버1);
+    final Long 멤버2_참가글_ID = eventService.participate(인프콘.getId(), requestMember2, 멤버2);
+
+    final List<ParticipantResponse> expected = List.of(
+        new ParticipantResponse(멤버1_참가글_ID, 멤버1.getId(), 멤버1.getName(), 멤버1.getImageUrl(),
+            멤버1.getDescription(), requestMember1.getContent()),
+        new ParticipantResponse(멤버2_참가글_ID, 멤버2.getId(), 멤버2.getName(), 멤버2.getImageUrl(),
+            멤버2.getDescription(), requestMember2.getContent())
+    );
 
     //when
     final List<ParticipantResponse> actual = eventService.findParticipants(인프콘.getId());
 
-    final List<ParticipantResponse> expected = List.of(
-        new ParticipantResponse(멤버1_참가글_ID, 멤버1.getId(), 멤버1.getName(), 멤버1.getImageUrl(),
-            멤버1.getDescription()),
-        new ParticipantResponse(멤버2_참가글_ID, 멤버2.getId(), 멤버2.getName(), 멤버2.getImageUrl(),
-            멤버2.getDescription())
-    );
     //then
     assertThat(actual)
         .usingRecursiveFieldByFieldElementComparator()

--- a/backend/emm-sale/src/test/java/com/emmsale/event/application/EventServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/application/EventServiceTest.java
@@ -143,9 +143,9 @@ class EventServiceTest extends ServiceIntegrationTestHelper {
 
     final List<ParticipantResponse> expected = List.of(
         new ParticipantResponse(멤버1_참가글_ID, 멤버1.getId(), 멤버1.getName(), 멤버1.getImageUrl(),
-            멤버1.getDescription(), requestMember1.getContent()),
+            멤버1.getDescription(), requestMember1.getContent(), LocalDate.now(), LocalDate.now()),
         new ParticipantResponse(멤버2_참가글_ID, 멤버2.getId(), 멤버2.getName(), 멤버2.getImageUrl(),
-            멤버2.getDescription(), requestMember2.getContent())
+            멤버2.getDescription(), requestMember2.getContent(), LocalDate.now(), LocalDate.now())
     );
 
     //when

--- a/backend/emm-sale/src/test/java/com/emmsale/event/domain/EventTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/domain/EventTest.java
@@ -120,9 +120,10 @@ class EventTest {
       //given
       final Event 인프콘 = eventFixture();
       final Member 멤버 = new Member(1L, 1L, "imageUrl", "멤버");
+      final String 내용 = "저랑 같이 갈 사람 구합니다.";
 
       //when
-      인프콘.addParticipant(멤버);
+      인프콘.addParticipant(멤버, 내용);
 
       //then
       final List<Member> members = 인프콘.getParticipants().stream()
@@ -139,10 +140,13 @@ class EventTest {
       //given
       final Event 인프콘 = eventFixture();
       final Member 멤버 = new Member(1L, 1L, "이미지URL", "멤버");
-      인프콘.addParticipant(멤버);
+      final String 내용 = "저랑 같이 갈 사람 구합니다.";
+
+      //when
+      인프콘.addParticipant(멤버, 내용);
 
       //when && then
-      assertThatThrownBy(() -> 인프콘.addParticipant(멤버))
+      assertThatThrownBy(() -> 인프콘.addParticipant(멤버, 내용))
           .isInstanceOf(EventException.class)
           .hasMessage(EventExceptionType.ALREADY_PARTICIPATED.errorMessage());
     }

--- a/backend/emm-sale/src/test/java/com/emmsale/event/domain/repository/ParticipantRepositoryTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/domain/repository/ParticipantRepositoryTest.java
@@ -39,7 +39,7 @@ class ParticipantRepositoryTest {
       //given
       final Event 인프콘 = eventRepository.save(인프콘_2023());
       final Member 멤버 = memberRepository.save(memberFixture());
-      participantRepository.save(new Participant(멤버, 인프콘));
+      participantRepository.save(new Participant(멤버, 인프콘, "빈 문자열"));
 
       //when
       final Boolean actual = participantRepository.existsByEventIdAndMemberId(인프콘.getId(),


### PR DESCRIPTION
## #️⃣연관된 이슈
- #253 

## 📝작업 내용
- 함께 해요 목록조회에 content와 createdAt, updatedAt 반환 구현
- event_member db 테이블 변경
  - column 2개 추가(createdAt, updatedAt)

## 예상 소요 시간 및 실제 소요 시간
- 1시간 / 2시간