### PR TITLE
Feature/#278 event 엔티티 태그 즉시로딩 제거

### DIFF
--- a/backend/emm-sale/src/main/java/com/emmsale/event/domain/Event.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/domain/Event.java
@@ -49,7 +49,7 @@ public class Event extends BaseEntity {
   @Column(nullable = false)
   private EventType type;
   private String imageUrl;
-  @OneToMany(mappedBy = "event", fetch = FetchType.EAGER, cascade = CascadeType.PERSIST)
+  @OneToMany(mappedBy = "event", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
   private List<EventTag> tags = new ArrayList<>();
   @OneToMany(mappedBy = "event")
   private List<Comment> comments;

--- a/backend/emm-sale/src/main/java/com/emmsale/event/domain/EventTag.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/domain/EventTag.java
@@ -23,7 +23,7 @@ public class EventTag {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "event_id", nullable = false)
   private Event event;
-  @ManyToOne(fetch = FetchType.EAGER)
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "tag_id", nullable = false)
   private Tag tag;
 

--- a/backend/emm-sale/src/test/java/com/emmsale/event/application/EventServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/application/EventServiceTest.java
@@ -61,6 +61,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -647,8 +648,14 @@ class EventServiceTest extends ServiceIntegrationTestHelper {
           () -> assertEquals(eventInformationUrl, savedEvent.getInformationUrl()),
           () -> assertEquals(beforeDateTime, savedEvent.getStartDate()),
           () -> assertEquals(afterDateTime, savedEvent.getEndDate())
-          // TODO: 2023/08/10 태그가 업데이트 되었는지 검증하는 로직 추가
       );
+
+      assertThat(response.getTags())
+          .containsAll(
+              tagRequests.stream()
+                  .map(TagRequest::getName)
+                  .collect(Collectors.toList())
+          );
     }
 
     @Test
@@ -744,7 +751,7 @@ class EventServiceTest extends ServiceIntegrationTestHelper {
       final Long eventId = event.getId();
 
       //when
-      eventService.updateEvent(eventId, updateRequest, now);
+      final EventDetailResponse response = eventService.updateEvent(eventId, updateRequest, now);
       final Event updatedEvent = eventRepository.findById(eventId).get();
 
       //then
@@ -754,8 +761,14 @@ class EventServiceTest extends ServiceIntegrationTestHelper {
           () -> assertEquals(newStartDateTime, updatedEvent.getStartDate()),
           () -> assertEquals(newEndDateTime, updatedEvent.getEndDate()),
           () -> assertEquals(newInformationUrl, updatedEvent.getInformationUrl())
-          // TODO: 2023/08/10 태그가 업데이트 되었는지 검증하는 로직 추가
       );
+
+      assertThat(response.getTags())
+          .containsAll(
+              newTagRequests.stream()
+                  .map(TagRequest::getName)
+                  .collect(Collectors.toList())
+          );
     }
 
     @Test

--- a/backend/emm-sale/src/test/java/com/emmsale/event/application/EventServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/application/EventServiceTest.java
@@ -61,7 +61,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -647,14 +646,8 @@ class EventServiceTest extends ServiceIntegrationTestHelper {
           () -> assertEquals(eventLocation, savedEvent.getLocation()),
           () -> assertEquals(eventInformationUrl, savedEvent.getInformationUrl()),
           () -> assertEquals(beforeDateTime, savedEvent.getStartDate()),
-          () -> assertEquals(afterDateTime, savedEvent.getEndDate()),
-          () -> assertThat(savedEvent.getTags()).extracting("tag", Tag.class)
-              .extracting("name", String.class)
-              .containsAll(
-                  tagRequests.stream()
-                      .map(TagRequest::getName)
-                      .collect(Collectors.toList())
-              )
+          () -> assertEquals(afterDateTime, savedEvent.getEndDate())
+          // TODO: 2023/08/10 태그가 업데이트 되었는지 검증하는 로직 추가
       );
     }
 
@@ -760,15 +753,8 @@ class EventServiceTest extends ServiceIntegrationTestHelper {
           () -> assertEquals(newLocation, updatedEvent.getLocation()),
           () -> assertEquals(newStartDateTime, updatedEvent.getStartDate()),
           () -> assertEquals(newEndDateTime, updatedEvent.getEndDate()),
-          () -> assertEquals(newInformationUrl, updatedEvent.getInformationUrl()),
-          () -> assertThat(updatedEvent.getTags())
-              .extracting("tag", Tag.class)
-              .extracting("name", String.class)
-              .containsAll(
-                  newTagRequests.stream()
-                      .map(TagRequest::getName)
-                      .collect(Collectors.toList())
-              )
+          () -> assertEquals(newInformationUrl, updatedEvent.getInformationUrl())
+          // TODO: 2023/08/10 태그가 업데이트 되었는지 검증하는 로직 추가
       );
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- #278 

close #278 

## 📝작업 내용
Event 엔티티의 태그 즉시 로딩 옵션 LAZY로 변경
태스트 수정

## 예상 소요 시간 및 실제 소요 시간
1시간 / 1시간