### PR TITLE
태그 목록 조회 API 구현

### DIFF
--- a/backend/emm-sale/src/docs/asciidoc/index.adoc
+++ b/backend/emm-sale/src/docs/asciidoc/index.adoc
@@ -381,3 +381,15 @@ include::{snippets}/register-block/http-request.adoc[]
 .HTTP response
 include::{snippets}/register-block/http-response.adoc[]
 
+== TAG
+
+=== 'GET' : 존재하는 모든 태그 조회
+
+.HTTP request
+include::{snippets}/find-tags/http-request.adoc[]
+
+.HTTP response
+include::{snippets}/find-tags/http-response.adoc[]
+
+.HTTP response 설명
+include::{snippets}/find-tags/response-fields.adoc[]

--- a/backend/emm-sale/src/main/java/com/emmsale/tag/api/TagApi.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/tag/api/TagApi.java
@@ -1,0 +1,23 @@
+package com.emmsale.tag.api;
+
+import com.emmsale.tag.application.TagQueryService;
+import com.emmsale.tag.application.dto.TagResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/tags")
+public class TagApi {
+
+  private final TagQueryService queryService;
+
+  @GetMapping
+  public ResponseEntity<List<TagResponse>> findAll() {
+    return ResponseEntity.ok(queryService.findAll());
+  }
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/tag/application/TagQueryService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/tag/application/TagQueryService.java
@@ -1,11 +1,15 @@
 package com.emmsale.tag.application;
 
+import static java.util.stream.Collectors.toUnmodifiableList;
+
 import com.emmsale.tag.application.dto.TagResponse;
 import com.emmsale.tag.domain.TagRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class TagQueryService {
@@ -13,6 +17,9 @@ public class TagQueryService {
   private final TagRepository tagRepository;
 
   public List<TagResponse> findAll() {
-    return null;
+    return tagRepository.findAll()
+        .stream()
+        .map(TagResponse::from)
+        .collect(toUnmodifiableList());
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/tag/application/TagQueryService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/tag/application/TagQueryService.java
@@ -1,0 +1,18 @@
+package com.emmsale.tag.application;
+
+import com.emmsale.tag.application.dto.TagResponse;
+import com.emmsale.tag.domain.TagRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TagQueryService {
+
+  private final TagRepository tagRepository;
+
+  public List<TagResponse> findAll() {
+    return null;
+  }
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/tag/application/dto/TagResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/tag/application/dto/TagResponse.java
@@ -1,5 +1,6 @@
 package com.emmsale.tag.application.dto;
 
+import com.emmsale.tag.domain.Tag;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -9,4 +10,8 @@ public class TagResponse {
 
   private final Long id;
   private final String name;
+
+  public static TagResponse from(final Tag tag) {
+    return new TagResponse(tag.getId(), tag.getName());
+  }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/tag/application/dto/TagResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/tag/application/dto/TagResponse.java
@@ -1,0 +1,12 @@
+package com.emmsale.tag.application.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TagResponse {
+
+  private final Long id;
+  private final String name;
+}

--- a/backend/emm-sale/src/main/resources/http/tag.http
+++ b/backend/emm-sale/src/main/resources/http/tag.http
@@ -1,0 +1,3 @@
+### 태그 전체 조회
+
+GET http://localhost:8080/tags

--- a/backend/emm-sale/src/test/java/com/emmsale/event/api/EventApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/api/EventApiTest.java
@@ -1,11 +1,9 @@
 package com.emmsale.event.api;
 
-import static java.lang.String.format;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;

--- a/backend/emm-sale/src/test/java/com/emmsale/tag/api/TagApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/tag/api/TagApiTest.java
@@ -1,0 +1,45 @@
+package com.emmsale.tag.api;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.emmsale.helper.MockMvcTestHelper;
+import com.emmsale.tag.application.TagQueryService;
+import com.emmsale.tag.application.dto.TagResponse;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+
+@WebMvcTest(TagApi.class)
+class TagApiTest extends MockMvcTestHelper {
+
+  @MockBean
+  private TagQueryService queryService;
+
+  @Test
+  @DisplayName("존재하는 태그를 전부 조회할 수 있다.")
+  void findAll() throws Exception {
+    //given
+    final List<TagResponse> responses = List.of(new TagResponse(1L, "백엔드"),
+        new TagResponse(2L, "안드로이드"), new TagResponse(3L, "프론트"));
+    when(queryService.findAll()).thenReturn(responses);
+
+    final ResponseFieldsSnippet responseFields = responseFields(
+        fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("태그 식별자"),
+        fieldWithPath("[].name").type(JsonFieldType.STRING).description("태그 이름")
+    );
+
+    //when & then
+    mockMvc.perform(get("/tags"))
+        .andExpect(status().isOk())
+        .andDo(document("find-tags", responseFields));
+  }
+}

--- a/backend/emm-sale/src/test/java/com/emmsale/tag/application/TagQueryServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/tag/application/TagQueryServiceTest.java
@@ -1,0 +1,42 @@
+package com.emmsale.tag.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.emmsale.helper.ServiceIntegrationTestHelper;
+import com.emmsale.tag.application.dto.TagResponse;
+import com.emmsale.tag.domain.Tag;
+import com.emmsale.tag.domain.TagRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class TagQueryServiceTest extends ServiceIntegrationTestHelper {
+
+  @Autowired
+  private TagQueryService queryService;
+  @Autowired
+  private TagRepository tagRepository;
+
+  @Test
+  @DisplayName("존재하는 태그를 전부 조회할 수 있다.")
+  void findAll() {
+    //given
+    final Tag 백엔드 = tagRepository.save(new Tag("백엔드"));
+    final Tag 안드로이드 = tagRepository.save(new Tag("안드로이드"));
+    final Tag 프론트엔드 = tagRepository.save(new Tag("프론트엔드"));
+    final List<TagResponse> expected = List.of(
+        TagResponse.from(백엔드),
+        TagResponse.from(안드로이드),
+        TagResponse.from(프론트엔드)
+    );
+
+    //when
+    final List<TagResponse> actual = queryService.findAll();
+
+    //then
+    assertThat(actual)
+        .usingRecursiveFieldByFieldElementComparator()
+        .containsExactlyInAnyOrderElementsOf(expected);
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- #144 

## 📝작업 내용
- 태그 목록을 조회하는 기능 구현

## 예상 소요 시간 및 실제 소요 시간
- 20분 / 20분