### PR TITLE
Fix/#334 댓글 알림 시 삭제된 댓글에 대한 알림 가지 않도록 처리

### DIFF
--- a/backend/emm-sale/src/main/java/com/emmsale/comment/application/CommentCommandService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/comment/application/CommentCommandService.java
@@ -86,6 +86,7 @@ public class CommentCommandService {
   ) {
     return comments.stream()
         .filter(it -> it.isNotMyComment(loginMember))
+        .filter(Comment::isNotDeleted)
         .collect(toMap(
             comment -> comment.getMember().getId(),
             comment -> comment,

--- a/backend/emm-sale/src/main/java/com/emmsale/comment/domain/Comment.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/comment/domain/Comment.java
@@ -52,6 +52,7 @@ public class Comment extends BaseEntity {
     this.parent = parent;
     this.member = member;
     this.content = content;
+    this.isDeleted = false;
   }
 
   public static Comment createRoot(
@@ -90,6 +91,10 @@ public class Comment extends BaseEntity {
 
   public boolean isNotMyComment(final Member member) {
     return this.member.isNotMe(member);
+  }
+
+  public boolean isNotDeleted() {
+    return !isDeleted || !content.equals(DELETED_COMMENT_MESSAGE);
   }
 
   public Optional<Comment> getParent() {

--- a/backend/emm-sale/src/test/java/com/emmsale/comment/application/CommentCommandServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/comment/application/CommentCommandServiceTest.java
@@ -150,13 +150,10 @@ class CommentCommandServiceTest extends ServiceIntegrationTestHelper {
   }
 
   /**
-   * 1
-   * ㄴ2  (1에게 알림)
-   * ㄴ3  (1,2에게 알림)
+   * 1 ㄴ2  (1에게 알림) ㄴ3  (1,2에게 알림)
    * <p>
-   *
-   * 새로운 대댓글
-   * ㄴ2  (1,3에게 알림)
+   * <p>
+   * 새로운 대댓글 ㄴ2  (1,3에게 알림)
    */
   @Test
   @DisplayName("create() : 자신이 작성한 댓글, 대댓글들 중에서 다른 사람이 댓글을 작성할 경우 알림이 온다.")
@@ -167,22 +164,95 @@ class CommentCommandServiceTest extends ServiceIntegrationTestHelper {
     final Member 댓글_작성자2 = memberRepository.findById(2L).get();
     final Member savedMember = memberRepository.save(new Member(200L, "imageUrl"));
     final Member 댓글_작성자3 = memberRepository.findById(savedMember.getId()).get();
+
     doNothing().when(eventPublisher).publish(any());
 
     final CommentAddRequest 부모_댓글_요청 = new CommentAddRequest(content, eventId, null);
     commentCommandService.create(부모_댓글_요청, 댓글_작성자);
+
+    // 댓글_작성자에게 알림 1번
     final CommentAddRequest 자식_댓글_요청1 = new CommentAddRequest(content, eventId, 1L);
     commentCommandService.create(자식_댓글_요청1, 댓글_작성자2);
+
+    // 댓글_작성자, 댓글_작성자2에게 알림 각각 1번
     final CommentAddRequest 자식_댓글_요청2 = new CommentAddRequest(content, eventId, 1L);
     commentCommandService.create(자식_댓글_요청2, 댓글_작성자3);
 
     final CommentAddRequest 알림이_가는_자식_댓글_요청 = new CommentAddRequest(content, eventId, 1L);
 
-    //when
+    //when  댓글_작성자, 댓글_작성자3에게 알림 각각 1번
     commentCommandService.create(알림이_가는_자식_댓글_요청, 댓글_작성자2);
 
     //then
     verify(eventPublisher, times(5)).publish(any());
+  }
+
+  @Test
+  @DisplayName("create() : 삭제된 댓글에 대해서는 알림이 가지 않는다.")
+  void test_create_not_notification_deletedComment() throws Exception {
+    //given
+    final String content = "내용";
+    final Long eventId = event.getId();
+    final Member 댓글_작성자2 = memberRepository.findById(2L).get();
+    final Member savedMember = memberRepository.save(new Member(200L, "imageUrl"));
+    final Member 댓글_작성자3 = memberRepository.findById(savedMember.getId()).get();
+
+    doNothing().when(eventPublisher).publish(any());
+
+    final CommentAddRequest 부모_댓글_요청 = new CommentAddRequest(content, eventId, null);
+    commentCommandService.create(부모_댓글_요청, 댓글_작성자);
+
+    // 댓글_작성자에게 알림 1번
+    final CommentAddRequest 자식_댓글_요청1 = new CommentAddRequest(content, eventId, 1L);
+    commentCommandService.create(자식_댓글_요청1, 댓글_작성자2);
+
+    // 댓글_작성자, 댓글_작성자2에게 알림 각각 1번
+    final CommentAddRequest 자식_댓글_요청2 = new CommentAddRequest(content, eventId, 1L);
+    final CommentResponse response = commentCommandService.create(자식_댓글_요청2, 댓글_작성자3);
+    commentCommandService.delete(response.getCommentId(), 댓글_작성자3);
+
+    final CommentAddRequest 알림이_가는_자식_댓글_요청 = new CommentAddRequest(content, eventId, 1L);
+
+    //when  댓글_작성자에게 알림 1번, 댓글_작성자3은 삭제된 댓글이므로 알림이 가지 않음
+    commentCommandService.create(알림이_가는_자식_댓글_요청, 댓글_작성자2);
+
+    //then
+    verify(eventPublisher, times(4)).publish(any());
+  }
+
+  @Test
+  @DisplayName("create() : 삭제된 댓글에 대해서는 알림이 가지 않는다.")
+  void test_create_not_notification_deletedComment2() throws Exception {
+    //given
+    final String content = "내용";
+    final Long eventId = event.getId();
+    final Member 댓글_작성자2 = memberRepository.findById(2L).get();
+    final Member savedMember = memberRepository.save(new Member(200L, "imageUrl"));
+    final Member 댓글_작성자3 = memberRepository.findById(savedMember.getId()).get();
+
+    doNothing().when(eventPublisher).publish(any());
+
+    final CommentAddRequest 부모_댓글_요청 = new CommentAddRequest(content, eventId, null);
+    final CommentResponse response = commentCommandService.create(부모_댓글_요청, 댓글_작성자);
+
+    // 댓글_작성자에게 알림 1번
+    final CommentAddRequest 자식_댓글_요청1 = new CommentAddRequest(content, eventId, 1L);
+    commentCommandService.create(자식_댓글_요청1, 댓글_작성자2);
+
+    // 댓글_작성자의 댓글 삭제
+    commentCommandService.delete(response.getCommentId(), 댓글_작성자);
+
+    // 댓글_작성자의 댓글은 삭제 -> 알림 X, 댓글_작성자2에게 알림 1번
+    final CommentAddRequest 자식_댓글_요청2 = new CommentAddRequest(content, eventId, 1L);
+    commentCommandService.create(자식_댓글_요청2, 댓글_작성자3);
+
+    final CommentAddRequest 알림이_가는_자식_댓글_요청 = new CommentAddRequest(content, eventId, 1L);
+
+    //when  댓글_작성자 삭제 -> 알림 X, 댓글_작성자3 알림 1번
+    commentCommandService.create(알림이_가는_자식_댓글_요청, 댓글_작성자2);
+
+    //then
+    verify(eventPublisher, times(3)).publish(any());
   }
 
   @Test
@@ -212,7 +282,7 @@ class CommentCommandServiceTest extends ServiceIntegrationTestHelper {
 
     assertAll(
         () -> assertTrue(updatedComment.isDeleted()),
-        () -> assertEquals(updatedComment.getContent(), "삭제된 댓글입니다.")
+        () -> assertEquals("삭제된 댓글입니다.", updatedComment.getContent())
     );
   }
 

--- a/backend/emm-sale/src/test/java/com/emmsale/comment/domain/CommentTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/comment/domain/CommentTest.java
@@ -10,9 +10,13 @@ import com.emmsale.member.MemberFixture;
 import com.emmsale.member.domain.Member;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class CommentTest {
 
@@ -65,4 +69,27 @@ class CommentTest {
     assertEquals(BLOCKED_MEMBER_CONTENT, actual);
   }
 
+  @ParameterizedTest
+  @MethodSource("commentCandidate")
+  @DisplayName("isNotDeleted() : 삭제 표시가 false이고 내용이 삭제된 댓글이 아닐 경우에 삭제되지 않은 댓글이라고 할 수 있다.")
+  void test_isNotDeleted(final Comment comment, final boolean result) throws Exception {
+    //when & then
+    assertEquals(comment.isNotDeleted(), result);
+  }
+
+  static Stream<Arguments> commentCandidate() {
+    final Event event = EventFixture.인프콘_2023();
+    final Member writer = MemberFixture.memberFixture();
+
+    final Comment comment1 = Comment.createRoot(event, writer, "댓글 내용");
+    final Comment comment2 = Comment.createRoot(event, writer, "댓글");
+    comment2.delete();
+    final Comment comment3 = Comment.createRoot(event, writer, "삭제된 댓글입니다.");
+
+    return Stream.of(
+        Arguments.of(comment1, true),
+        Arguments.of(comment2, false),
+        Arguments.of(comment3, true)
+    );
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- #334 

## 📝작업 내용

댓글 알림 시 삭제된 댓글에 대한 알림 가지 않도록 처리

테스트 한 두개정도 더 추가했어요



## 예상 소요 시간 및 실제 소요 시간
2시간 / 1시간

