### PR TITLE
hotfix : api 문서에서 queryParam 값들을 카멜 케이스로 받아오도록 수정

### DIFF
--- a/backend/emm-sale/src/test/java/com/emmsale/notification/api/RequestNotificationApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/notification/api/RequestNotificationApiTest.java
@@ -283,9 +283,9 @@ class RequestNotificationApiTest extends MockMvcTestHelper {
 
     //when & then
     mockMvc.perform(get("/request-notifications/existed")
-            .queryParam("receiver-id", "1")
-            .queryParam("sender-id", "2")
-            .queryParam("event-id", "3")
+            .queryParam("receiverId", "1")
+            .queryParam("senderId", "2")
+            .queryParam("eventId", "3")
             .header("Authorization", accessToken))
         .andExpect(status().isOk())
         .andDo(print())

--- a/backend/emm-sale/src/test/java/com/emmsale/notification/api/UpdateNotificationApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/notification/api/UpdateNotificationApiTest.java
@@ -92,7 +92,7 @@ class UpdateNotificationApiTest extends MockMvcTestHelper {
 
     //then
     mockMvc.perform(get("/update-notifications")
-            .queryParam("member-id", "1")
+            .queryParam("memberId", "1")
             .header("Authorization", accessToken))
         .andExpect(status().isOk())
         .andDo(print())


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #341 

## 📝작업 내용

rest docs query-param 카멜 케이스로 받아오도록 수정

## 예상 소요 시간 및 실제 소요 시간
5분 / 5분
