### PR TITLE
feat: 관심 카테고리 선택 개수를 4개로 제한

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/common/extension/ContextExt.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/common/extension/ContextExt.kt
@@ -12,6 +12,7 @@ import android.net.Uri
 import android.os.Build
 import android.provider.Settings
 import android.widget.Toast
+import androidx.annotation.StringRes
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -20,6 +21,10 @@ import java.time.LocalDate
 
 fun Context.showToast(text: String) {
     Toast.makeText(this, text, Toast.LENGTH_SHORT).show()
+}
+
+fun Context.showToast(@StringRes textResId: Int) {
+    showToast(getString(textResId))
 }
 
 fun Context.checkPostNotificationPermission(): Boolean {

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/common/extension/FragmentExt.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/common/extension/FragmentExt.kt
@@ -1,7 +1,12 @@
 package com.emmsale.presentation.common.extension
 
+import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
 
 fun Fragment.showToast(text: String) {
     requireContext().showToast(text)
+}
+
+fun Fragment.showToast(@StringRes textResId: Int) {
+    showToast(getString(textResId))
 }

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/onboarding/OnboardingViewModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/onboarding/OnboardingViewModel.kt
@@ -26,6 +26,9 @@ class OnboardingViewModel(
     private val _activities = NotNullMutableLiveData(OnboardingUiState())
     val activities: NotNullLiveData<OnboardingUiState> = _activities
 
+    val isExceedFieldLimit: Boolean
+        get() = activities.value.fields.count { it.isSelected } == MAXIMUM_FIELD_SELECTION
+
     init {
         _activities.value = _activities.value.copy(isLoading = true)
         fetchActivities()
@@ -73,6 +76,8 @@ class OnboardingViewModel(
     }
 
     companion object {
+        private const val MAXIMUM_FIELD_SELECTION = 4
+
         val factory = ViewModelFactory {
             OnboardingViewModel(
                 activityRepository = KerdyApplication.repositoryContainer.activityRepository,

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/onboarding/field/OnboardingFieldFragment.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/onboarding/field/OnboardingFieldFragment.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.activityViewModels
 import com.emmsale.R
 import com.emmsale.databinding.FragmentOnboardingFieldBinding
 import com.emmsale.presentation.base.BaseFragment
+import com.emmsale.presentation.common.extension.showToast
 import com.emmsale.presentation.common.views.activityChipOf
 import com.emmsale.presentation.ui.onboarding.OnboardingActivity
 import com.emmsale.presentation.ui.onboarding.OnboardingViewModel
@@ -44,6 +45,12 @@ class OnboardingFieldFragment :
         text = activity.name
         isChecked = activity.isSelected
         setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked && viewModel.isExceedFieldLimit) {
+                showToast(R.string.onboarding_field_selection_limit_exceed)
+                setChecked(false)
+                return@setOnCheckedChangeListener
+            }
+
             viewModel.updateSelection(activity.id, isChecked)
         }
     }

--- a/android/2023-emmsale/app/src/main/res/values/strings.xml
+++ b/android/2023-emmsale/app/src/main/res/values/strings.xml
@@ -227,4 +227,5 @@
     <string name="primarynotification_delete_notification_failed_message">알림 삭제를 할 수 없어요!</string>
     <string name="primarynotification_delete_notification_confirm_message">지난 알림을 모두 삭제하시겠어요?</string>
     <string name="primarynotification_delete_notification_confirm_title">알림 삭제</string>
+    <string name="onboarding_field_selection_limit_exceed">선택할 수 있는 개수를 초과했어요!</string>
 </resources>


### PR DESCRIPTION
- 초과시 선택이 해제되며, 경고 문구를 보여준다.

## #️⃣연관된 이슈
>  ex) #323

## 📝작업 내용
> 관심 카테고리를 4개 초과시, 경고 문구를 출력하고 더 이상 선택을 하지 못하도록 막는 기능을 추가하였습니다.

### 스크린샷 (선택)
<img width="401" alt="스크린샷 2023-08-15 오전 2 41 00" src="https://github.com/woowacourse-teams/2023-emmsale/assets/56534241/eb80c923-1a65-4403-9211-c7fd01cbabf4">

## 예상 소요 시간 및 실제 소요 시간
> 30분/10분

## 💬리뷰 요구사항(선택)

> 기존에 이야기 되었던 것처럼, 간단한 작업에 대해서 시간상 바로 merge하도록 하겠습니다.