### PR TITLE
feat: 함께해요 요청 알림에서 카카오톡 오픈 채팅으로 이동하는 기능 구현

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/member/Member.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/member/Member.kt
@@ -2,7 +2,9 @@ package com.emmsale.data.member
 
 data class Member(
     val id: Long,
+    val githubId: String,
     val name: String,
     val description: String,
     val imageUrl: String,
+    val openProfileUrl: String,
 )

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/member/dto/MemberApiModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/member/dto/MemberApiModel.kt
@@ -7,10 +7,14 @@ import kotlinx.serialization.Serializable
 data class MemberApiModel(
     @SerialName("id")
     val id: Long,
+    @SerialName("githubId")
+    val githubId: String = "",
     @SerialName("name")
     val name: String,
     @SerialName("description")
     val description: String = "",
     @SerialName("imageUrl")
     val imageUrl: String,
+    @SerialName("openProfileUrl")
+    val openProfileUrl: String = "",
 )

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/member/mapper/MemberMapper.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/member/mapper/MemberMapper.kt
@@ -5,7 +5,9 @@ import com.emmsale.data.member.dto.MemberApiModel
 
 fun MemberApiModel.toData() = Member(
     id = id,
+    githubId = githubId,
     name = name,
     description = description,
     imageUrl = imageUrl,
+    openProfileUrl = openProfileUrl,
 )

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/RecruitmentNotificationFragment.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/RecruitmentNotificationFragment.kt
@@ -1,5 +1,7 @@
 package com.emmsale.presentation.ui.notificationBox.recruitmentNotification
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
@@ -18,6 +20,7 @@ class RecruitmentNotificationFragment :
     BaseFragment<FragmentRecruitmentNotificationBinding>(),
     RecruitmentNotificationHeaderClickListener,
     RecruitmentNotificationBodyClickListener {
+
     override val layoutResId: Int = R.layout.fragment_recruitment_notification
     private val viewModel: RecruitmentNotificationViewModel by viewModels { RecruitmentNotificationViewModel.factory }
     private val recruitmentNotificationHeaderAdapter: RecruitmentNotificationHeaderAdapter by lazy {
@@ -51,6 +54,17 @@ class RecruitmentNotificationFragment :
 
     override fun onMoreButtonClick(notificationId: Long) {
         viewModel.reportRecruitmentNotification(notificationId)
+    }
+
+    override fun onOpenChatButtonClick(openChatUrl: String) {
+        if (openChatUrl.isEmpty()) return
+
+        navigateToChat(openChatUrl)
+    }
+
+    private fun navigateToChat(chatUrl: String) {
+        val profileIntent = Intent(Intent.ACTION_VIEW, Uri.parse(chatUrl))
+        startActivity(profileIntent)
     }
 
     private fun showRecruitmentRejectedConfirmDialog(notificationId: Long) {

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/RecruitmentNotificationFragment.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/RecruitmentNotificationFragment.kt
@@ -57,9 +57,16 @@ class RecruitmentNotificationFragment :
     }
 
     override fun onOpenChatButtonClick(openChatUrl: String) {
-        if (openChatUrl.isEmpty()) return
+        if (openChatUrl.isEmpty()) {
+            showUnregisteredOpenChatUrlErrorMessage()
+            return
+        }
 
         navigateToChat(openChatUrl)
+    }
+
+    private fun showUnregisteredOpenChatUrlErrorMessage() {
+        binding.root.showSnackbar(R.string.recruitmentnotification_unregistered_sender_open_chat_url)
     }
 
     private fun navigateToChat(chatUrl: String) {

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/RecruitmentNotificationViewModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/RecruitmentNotificationViewModel.kt
@@ -97,7 +97,7 @@ class RecruitmentNotificationViewModel(
                 is ApiSuccess -> RecruitmentNotificationMemberUiState(
                     name = member.data.name,
                     profileImageUrl = member.data.imageUrl,
-                    openProfileUrl = member.data.openProfileUrl,
+                    openChatUrl = member.data.openProfileUrl,
                 )
 
                 is ApiException, is ApiError -> null

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/RecruitmentNotificationViewModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/RecruitmentNotificationViewModel.kt
@@ -95,8 +95,9 @@ class RecruitmentNotificationViewModel(
         viewModelScope.async {
             when (val member = memberRepository.getMember(userId)) {
                 is ApiSuccess -> RecruitmentNotificationMemberUiState(
-                    member.data.name,
-                    member.data.imageUrl,
+                    name = member.data.name,
+                    profileImageUrl = member.data.imageUrl,
+                    openProfileUrl = member.data.openProfileUrl,
                 )
 
                 is ApiException, is ApiError -> null

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/recyclerview/body/RecruitmentNotificationBodyClickListener.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/recyclerview/body/RecruitmentNotificationBodyClickListener.kt
@@ -4,4 +4,5 @@ interface RecruitmentNotificationBodyClickListener {
     fun onAcceptButtonClick(notificationId: Long)
     fun onRejectButtonClick(notificationId: Long)
     fun onMoreButtonClick(notificationId: Long)
+    fun onOpenChatButtonClick(openChatUrl: String)
 }

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/uistate/RecruitmentNotificationBodyUiState.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/uistate/RecruitmentNotificationBodyUiState.kt
@@ -14,7 +14,7 @@ data class RecruitmentNotificationBodyUiState(
     val profileImageUrl: String,
     val notificationDate: String,
     val recruitmentStatus: RecruitmentNotificationStatusUiState,
-    val openProfileUrl: String,
+    val openChatUrl: String,
     val isRead: Boolean = false,
 ) {
     fun changeToAcceptedState(): RecruitmentNotificationBodyUiState = copy(
@@ -44,7 +44,7 @@ data class RecruitmentNotificationBodyUiState(
             profileImageUrl = notificationMember?.profileImageUrl ?: "",
             notificationDate = recruitmentNotification.notificationDate.toUiString(),
             recruitmentStatus = RecruitmentNotificationStatusUiState.from(recruitmentNotification.status),
-            openProfileUrl = notificationMember?.openProfileUrl ?: "",
+            openChatUrl = notificationMember?.openChatUrl ?: "",
             isRead = recruitmentNotification.isRead,
         )
 

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/uistate/RecruitmentNotificationBodyUiState.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/uistate/RecruitmentNotificationBodyUiState.kt
@@ -14,6 +14,7 @@ data class RecruitmentNotificationBodyUiState(
     val profileImageUrl: String,
     val notificationDate: String,
     val recruitmentStatus: RecruitmentNotificationStatusUiState,
+    val openProfileUrl: String,
     val isRead: Boolean = false,
 ) {
     fun changeToAcceptedState(): RecruitmentNotificationBodyUiState = copy(
@@ -43,6 +44,7 @@ data class RecruitmentNotificationBodyUiState(
             profileImageUrl = notificationMember?.profileImageUrl ?: "",
             notificationDate = recruitmentNotification.notificationDate.toUiString(),
             recruitmentStatus = RecruitmentNotificationStatusUiState.from(recruitmentNotification.status),
+            openProfileUrl = notificationMember?.openProfileUrl ?: "",
             isRead = recruitmentNotification.isRead,
         )
 

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/uistate/RecruitmentNotificationMemberUiState.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/uistate/RecruitmentNotificationMemberUiState.kt
@@ -3,5 +3,5 @@ package com.emmsale.presentation.ui.notificationBox.recruitmentNotification.uist
 data class RecruitmentNotificationMemberUiState(
     val name: String,
     val profileImageUrl: String,
-    val openProfileUrl: String,
+    val openChatUrl: String,
 )

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/uistate/RecruitmentNotificationMemberUiState.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/uistate/RecruitmentNotificationMemberUiState.kt
@@ -3,4 +3,5 @@ package com.emmsale.presentation.ui.notificationBox.recruitmentNotification.uist
 data class RecruitmentNotificationMemberUiState(
     val name: String,
     val profileImageUrl: String,
+    val openProfileUrl: String,
 )

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/onboarding/field/OnboardingFieldFragment.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/onboarding/field/OnboardingFieldFragment.kt
@@ -46,7 +46,7 @@ class OnboardingFieldFragment :
         isChecked = activity.isSelected
         setOnCheckedChangeListener { _, isChecked ->
             if (isChecked && viewModel.isExceedFieldLimit) {
-                showToast(R.string.onboarding_field_selection_limit_exceed)
+                showToast(R.string.onboardingfield_selection_limit_exceed)
                 setChecked(false)
                 return@setOnCheckedChangeListener
             }

--- a/android/2023-emmsale/app/src/main/res/layout/item_recruitment_notification_body.xml
+++ b/android/2023-emmsale/app/src/main/res/layout/item_recruitment_notification_body.xml
@@ -146,6 +146,7 @@
             android:clickable="true"
             android:focusable="true"
             android:gravity="center"
+            android:onClick="@{() -> notificationBodyClickListener.onOpenChatButtonClick(notification.openProfileUrl)}"
             android:paddingVertical="12dp"
             android:text="@string/recruitmentnotification_open_chat"
             android:textColor="@color/white"

--- a/android/2023-emmsale/app/src/main/res/layout/item_recruitment_notification_body.xml
+++ b/android/2023-emmsale/app/src/main/res/layout/item_recruitment_notification_body.xml
@@ -146,7 +146,7 @@
             android:clickable="true"
             android:focusable="true"
             android:gravity="center"
-            android:onClick="@{() -> notificationBodyClickListener.onOpenChatButtonClick(notification.openProfileUrl)}"
+            android:onClick="@{() -> notificationBodyClickListener.onOpenChatButtonClick(notification.openChatUrl)}"
             android:paddingVertical="12dp"
             android:text="@string/recruitmentnotification_open_chat"
             android:textColor="@color/white"

--- a/android/2023-emmsale/app/src/main/res/values/strings.xml
+++ b/android/2023-emmsale/app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="onboardingfield_title">관심 분야</string>
     <string name="onboardingfield_message">관심 있는 카테고리를 선택해 주세요.</string>
     <string name="onboardingfield_sub_message">복수 선택이 최대 4개까지 가능합니다.</string>
+    <string name="onboardingfield_selection_limit_exceed">선택할 수 있는 개수를 초과했어요!</string>
 
     <string name="eventdetail_date_format">%s ~ %s</string>
     <string name="onboardingeducation_page">3/4</string>
@@ -155,6 +156,7 @@
     <string name="recruitmentnotification_reject_button_label">요청을 거절했습니다.</string>
     <string name="recruitmentnotification_more_button">더보기 버튼</string>
     <string name="recruitmentnotification_header_expand_view">화면을 팽창 시킵니다.</string>
+    <string name="recruitmentnotification_unregistered_sender_open_chat_url">상대방의 오픈 채팅이 등록되어 있지 않아요!</string>
 
     <string name="conference_default_people_count">0</string>
 
@@ -227,5 +229,4 @@
     <string name="primarynotification_delete_notification_failed_message">알림 삭제를 할 수 없어요!</string>
     <string name="primarynotification_delete_notification_confirm_message">지난 알림을 모두 삭제하시겠어요?</string>
     <string name="primarynotification_delete_notification_confirm_title">알림 삭제</string>
-    <string name="onboarding_field_selection_limit_exceed">선택할 수 있는 개수를 초과했어요!</string>
 </resources>


### PR DESCRIPTION
## #️⃣연관된 이슈
>  ex) #333

## 📝작업 내용
> 오픈 채팅방 링크 클릭시 카카오톡 오픈 채팅방 링크로 이동한다.
> 올바르지 않은 오픈 채팅 URL인 경우 에러 문구를 보여준다.

### 스크린샷 (선택)
<img width="378" alt="스크린샷 2023-08-15 오후 12 34 01" src="https://github.com/woowacourse-teams/2023-emmsale/assets/56534241/10cbc0c4-e064-4162-8ffc-75d63aeebe1b">


<img width="387" alt="스크린샷 2023-08-15 오후 12 32 33" src="https://github.com/woowacourse-teams/2023-emmsale/assets/56534241/40c5348e-009f-40f6-8a9d-76c246e42be0">

## 예상 소요 시간 및 실제 소요 시간
1시간/20분

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 현재 백엔드에서 Member 데이터 클래스의 GithubId와 openProfileUrl을 함께 보내주도록 변경하고 있습니다.
그렇기 때문에, openProfile을 등록하였더라도, 정상적으로 동작하지 않을 수 있는 점은 감안해주세요 : )
- 기존에 이야기 되었던 것처럼, 간단한 작업에 대해서 시간상 바로 merge하도록 하겠습니다.