### PR TITLE
Feature/#284-반환 데이터의 날짜 포맷을 하나로 통일

### DIFF
--- a/backend/emm-sale/src/main/java/com/emmsale/comment/application/dto/CommentResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/comment/application/dto/CommentResponse.java
@@ -15,14 +15,16 @@ import lombok.NoArgsConstructor;
 @Getter
 public class CommentResponse {
 
+  private static final String DATE_TIME_FORMAT = "yyyy:MM:dd:HH:mm:ss";
+
   private String content;
   private Long commentId;
   private Long parentId;
   private Long eventId;
   private boolean isDeleted;
-  @JsonFormat(pattern = "yyyy:MM:dd:HH:mm:ss")
+  @JsonFormat(pattern = DATE_TIME_FORMAT)
   private LocalDateTime createdAt;
-  @JsonFormat(pattern = "yyyy:MM:dd:HH:mm:ss")
+  @JsonFormat(pattern = DATE_TIME_FORMAT)
   private LocalDateTime updatedAt;
   private Long memberId;
   private String memberImageUrl;

--- a/backend/emm-sale/src/main/java/com/emmsale/event/application/dto/EventDetailRequest.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/application/dto/EventDetailRequest.java
@@ -16,7 +16,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 @Getter
 public class EventDetailRequest {
 
-  private static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
+  private static final String DATE_TIME_FORMAT = "yyyy:MM:dd:HH:mm:ss";
 
   @NotBlank(message = "행사의 이름을 입력해 주세요.")
   private final String name;

--- a/backend/emm-sale/src/main/java/com/emmsale/event/application/dto/RecruitmentPostResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/application/dto/RecruitmentPostResponse.java
@@ -11,7 +11,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 @Getter
 public class RecruitmentPostResponse {
 
-  private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
+  private static final String DATE_TIME_FORMAT = "yyyy:MM:dd:HH:mm:ss";
 
   private final Long id;
   private final Long memberId;

--- a/backend/emm-sale/src/test/java/com/emmsale/event/api/EventApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/api/EventApiTest.java
@@ -102,9 +102,9 @@ class EventApiTest extends MockMvcTestHelper {
     // given
     final RequestParametersSnippet requestParameters = requestParameters(
         parameterWithName("category").description("행사 카테고리(CONFERENCE, COMPETITION)"),
-        parameterWithName("start_date").description("필터링하려는 기간의 시작일(yyyy-mm-dd)(option)")
+        parameterWithName("start_date").description("필터링하려는 기간의 시작일(yyyy:mm:dd)(option)")
             .optional(),
-        parameterWithName("end_date").description("필터링하려는 기간의 끝일(yyyy-mm-dd)(option)").optional(),
+        parameterWithName("end_date").description("필터링하려는 기간의 끝일(yyyy:mm:dd)(option)").optional(),
         parameterWithName("tags").description("필터링하려는 태그(option)").optional(),
         parameterWithName("statuses").description("필터링하려는 상태(UPCOMING, IN_PROGRESS, ENDED)(option)")
             .optional()


### PR DESCRIPTION
## #️⃣연관된 이슈
>  ex) #284

## 📝작업 내용
날짜 포맷을 `yyyy:MM:dd:HH:mm:ss`로 통일했습니다.

## 예상 소요 시간 및 실제 소요 시간
10분/테스트포함5분