### PR TITLE
Feature/#357 사용자 차단 목록 조회

### DIFF
--- a/backend/emm-sale/src/docs/asciidoc/index.adoc
+++ b/backend/emm-sale/src/docs/asciidoc/index.adoc
@@ -486,13 +486,13 @@ include::{snippets}/register-block/http-response.adoc[]
 === `GET` : 차단한 사용자 목록 조회
 
 .HTTP request
-include::{snippets}/get-blocks/http-request.adoc[]
+include::{snippets}/find-blocks/http-request.adoc[]
 
 .HTTP response
-include::{snippets}/get-blocks/http-response.adoc[]
+include::{snippets}/find-blocks/http-response.adoc[]
 
 .HTTP response 설명
-include::{snippets}/get-blocks/response-fields.adoc[]
+include::{snippets}/find-blocks/response-fields.adoc[]
 
 == TAG
 

--- a/backend/emm-sale/src/docs/asciidoc/index.adoc
+++ b/backend/emm-sale/src/docs/asciidoc/index.adoc
@@ -483,6 +483,17 @@ include::{snippets}/register-block/http-request.adoc[]
 .HTTP response
 include::{snippets}/register-block/http-response.adoc[]
 
+=== `GET` : 차단한 사용자 목록 조회
+
+.HTTP request
+include::{snippets}/get-blocks/http-request.adoc[]
+
+.HTTP response
+include::{snippets}/get-blocks/http-response.adoc[]
+
+.HTTP response 설명
+include::{snippets}/get-blocks/response-fields.adoc[]
+
 == TAG
 
 === `GET` : 존재하는 모든 태그 조회

--- a/backend/emm-sale/src/main/java/com/emmsale/block/api/BlockApi.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/block/api/BlockApi.java
@@ -31,7 +31,7 @@ public class BlockApi {
   }
 
   @GetMapping
-  public ResponseEntity<List<BlockResponse>> getBlockMembers(final Member member) {
+  public ResponseEntity<List<BlockResponse>> findBlockMembers(final Member member) {
     final List<BlockResponse> responses = blockQueryService.findAll(member);
     return ResponseEntity.ok(responses);
   }

--- a/backend/emm-sale/src/main/java/com/emmsale/block/api/BlockApi.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/block/api/BlockApi.java
@@ -1,10 +1,15 @@
 package com.emmsale.block.api;
 
 import com.emmsale.block.application.BlockCommandService;
+import com.emmsale.block.application.BlockQueryService;
 import com.emmsale.block.application.dto.BlockRequest;
+import com.emmsale.block.application.dto.BlockResponse;
 import com.emmsale.member.domain.Member;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,10 +22,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class BlockApi {
 
   public final BlockCommandService blockCommandService;
+  public final BlockQueryService blockQueryService;
 
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
   public void register(@RequestBody final BlockRequest blockRequest, final Member member) {
     blockCommandService.register(member, blockRequest);
+  }
+
+  @GetMapping
+  public ResponseEntity<List<BlockResponse>> getBlockMembers(final Member member) {
+    final List<BlockResponse> responses = blockQueryService.findAll(member);
+    return ResponseEntity.ok(responses);
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/block/application/BlockQueryService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/block/application/BlockQueryService.java
@@ -1,0 +1,38 @@
+package com.emmsale.block.application;
+
+import static java.util.stream.Collectors.toUnmodifiableList;
+
+import com.emmsale.block.application.dto.BlockResponse;
+import com.emmsale.block.domain.Block;
+import com.emmsale.block.domain.BlockRepository;
+import com.emmsale.block.exception.BlockException;
+import com.emmsale.block.exception.BlockExceptionType;
+import com.emmsale.member.domain.Member;
+import com.emmsale.member.domain.MemberRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class BlockQueryService {
+
+  private final BlockRepository blockRepository;
+  private final MemberRepository memberRepository;
+
+  public List<BlockResponse> findAll(final Member member) {
+    return blockRepository.findAllByRequestMemberId(member.getId())
+        .stream()
+        .map(this::convertTo)
+        .collect(toUnmodifiableList());
+  }
+
+  private BlockResponse convertTo(final Block block) {
+    final Member member = memberRepository.findById(block.getBlockMemberId())
+        .orElseThrow(() -> new BlockException(BlockExceptionType.NOT_FOUND_MEMBER));
+    return BlockResponse.from(block, member);
+  }
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/block/application/dto/BlockResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/block/application/dto/BlockResponse.java
@@ -1,0 +1,25 @@
+package com.emmsale.block.application.dto;
+
+import com.emmsale.block.domain.Block;
+import com.emmsale.member.domain.Member;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class BlockResponse {
+
+  private final Long id;
+  private final Long blockMemberId;
+  private final String imageUrl;
+  private final String memberName;
+
+  public static BlockResponse from(final Block block, final Member member) {
+    return new BlockResponse(
+        block.getId(),
+        member.getId(),
+        member.getImageUrl(),
+        member.getName()
+    );
+  }
+}

--- a/backend/emm-sale/src/test/java/com/emmsale/block/api/BlockApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/block/api/BlockApiTest.java
@@ -1,29 +1,40 @@
 package com.emmsale.block.api;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.emmsale.block.application.BlockCommandService;
+import com.emmsale.block.application.BlockQueryService;
 import com.emmsale.block.application.dto.BlockRequest;
+import com.emmsale.block.application.dto.BlockResponse;
 import com.emmsale.helper.MockMvcTestHelper;
 import com.emmsale.member.MemberFixture;
 import com.emmsale.member.domain.Member;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.restdocs.payload.RequestFieldsSnippet;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
 
 @WebMvcTest(BlockApi.class)
 class BlockApiTest extends MockMvcTestHelper {
 
   @MockBean
   private BlockCommandService blockCommandService;
+  @MockBean
+  private BlockQueryService blockQueryService;
 
   @Test
   @DisplayName("성공적으로 사용자를 차단할 경우 201 CREATED를 반환한다.")
@@ -48,5 +59,33 @@ class BlockApiTest extends MockMvcTestHelper {
             .content(objectMapper.writeValueAsString(blockRequest)))
         .andExpect(status().isCreated())
         .andDo(document("register-block", requestFields));
+  }
+
+  @Test
+  @DisplayName("차단되 사용자들을 전부 조회한다.")
+  void findAllTest() throws Exception {
+    //given
+    final String accessToken = "Bearer accessToken";
+    final List<BlockResponse> responses = List.of(
+        new BlockResponse(1L, 2L, "2번 멤버 이미지Url", "2번 멤버"),
+        new BlockResponse(2L, 4L, "4번 멤버 이미지Url", "4번 멤버")
+    );
+
+    final ResponseFieldsSnippet responseFields = responseFields(
+        fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("차단 id"),
+        fieldWithPath("[].blockMemberId").type(JsonFieldType.NUMBER).description("차단한 사용자의 id"),
+        fieldWithPath("[].imageUrl").type(JsonFieldType.STRING).description("차단한 사용자의 이미지 url"),
+        fieldWithPath("[].memberName").type(JsonFieldType.STRING).description("차단한 사용자의 이름")
+    );
+
+    //when
+    when(blockQueryService.findAll(any())).thenReturn(responses);
+
+    //then
+    mockMvc.perform(get("/blocks")
+            .header("Authorization", accessToken)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated())
+        .andDo(document("get-blocks", responseFields));
   }
 }

--- a/backend/emm-sale/src/test/java/com/emmsale/block/api/BlockApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/block/api/BlockApiTest.java
@@ -62,7 +62,7 @@ class BlockApiTest extends MockMvcTestHelper {
   }
 
   @Test
-  @DisplayName("차단되 사용자들을 전부 조회한다.")
+  @DisplayName("차단된 사용자들을 전부 조회한다.")
   void findAllTest() throws Exception {
     //given
     final String accessToken = "Bearer accessToken";
@@ -85,7 +85,7 @@ class BlockApiTest extends MockMvcTestHelper {
     mockMvc.perform(get("/blocks")
             .header("Authorization", accessToken)
             .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isCreated())
-        .andDo(document("get-blocks", responseFields));
+        .andExpect(status().isOk())
+        .andDo(document("find-blocks", responseFields));
   }
 }

--- a/backend/emm-sale/src/test/java/com/emmsale/block/application/BlockQueryServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/block/application/BlockQueryServiceTest.java
@@ -1,0 +1,53 @@
+package com.emmsale.block.application;
+
+import static com.emmsale.member.MemberFixture.memberFixture;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.emmsale.block.application.dto.BlockResponse;
+import com.emmsale.block.domain.Block;
+import com.emmsale.block.domain.BlockRepository;
+import com.emmsale.helper.ServiceIntegrationTestHelper;
+import com.emmsale.member.domain.Member;
+import com.emmsale.member.domain.MemberRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class BlockQueryServiceTest extends ServiceIntegrationTestHelper {
+
+  @Autowired
+  private BlockRepository blockRepository;
+  @Autowired
+  private BlockQueryService queryService;
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @Test
+  @DisplayName("사용자의 차단 목록 전체 조회할 수 있다.")
+  void findAllTest() {
+    //given
+    final Member requestMember = memberRepository.findById(1L).get();
+    final Member blockMember_1 = memberRepository.findById(2L).get();
+    final Member blockMember_2 = memberRepository.save(memberFixture());
+
+    final Block block1 = blockRepository.save(new Block(1L, blockMember_1.getId()));
+    final Block block2 = blockRepository.save(new Block(1L, blockMember_2.getId()));
+
+    final List<BlockResponse> expected = List.of(
+        new BlockResponse(block1.getId(), blockMember_1.getId(), blockMember_1.getImageUrl(),
+            blockMember_1.getName()),
+        new BlockResponse(block2.getId(), blockMember_2.getId(), blockMember_2.getImageUrl(),
+            blockMember_2.getName())
+    );
+
+    //when
+    final List<BlockResponse> actual = queryService.findAll(requestMember);
+
+    //then
+    assertThat(actual)
+        .usingRecursiveComparison()
+        .ignoringCollectionOrder()
+        .isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- #357 

## 📝작업 내용
- 사용자 차단 목록 조회

## 예상 소요 시간 및 실제 소요 시간
- 20분 / 1시간

## 💬리뷰 요구사항(선택)
- block에서 member를 간접참조 하고 있어서,  Member하나당 쿼리를 한번 씩 쏘는데 이걸 어떻게 풀어야 할까요?
그냥 로직적으로 AllByIds로 한 번에 조회한 후에, 매칭하는 식으로 찾아가야 할까요?