### PR TITLE
Feature/#366 MemberActivity 수정 API 구현

### DIFF
--- a/backend/emm-sale/src/docs/asciidoc/index.adoc
+++ b/backend/emm-sale/src/docs/asciidoc/index.adoc
@@ -8,34 +8,6 @@
 
 == Activity
 
-=== `POST`: Activity 등록 API
-
-.HTTP request 설명
-include::{snippets}/add-activity/request-fields.adoc[]
-
-.HTTP request
-include::{snippets}/add-activity/http-request.adoc[]
-
-.HTTP response
-include::{snippets}/add-activity/http-response.adoc[]
-
-.HTTP response 설명
-include::{snippets}/add-activity/response-fields.adoc[]
-
-=== `DELETE`: Activity 삭제 API
-
-.HTTP request 설명
-include::{snippets}/delete-activity/request-fields.adoc[]
-
-.HTTP request
-include::{snippets}/delete-activity/http-request.adoc[]
-
-.HTTP response
-include::{snippets}/delete-activity/http-response.adoc[]
-
-.HTTP response 설명
-include::{snippets}/delete-activity/response-fields.adoc[]
-
 === `GET`: 존재하는 Activity 전체 조회
 
 .HTTP request
@@ -46,17 +18,6 @@ include::{snippets}/find-all-activities/http-response.adoc[]
 
 .HTTP response 설명
 include::{snippets}/find-all-activities/response-fields.adoc[]
-
-=== `GET`: 사용자의 Activity 조회
-
-.HTTP request
-include::{snippets}/find-activity/http-request.adoc[]
-
-.HTTP response
-include::{snippets}/find-activity/http-response.adoc[]
-
-.HTTP response 설명
-include::{snippets}/find-activity/response-fields.adoc[]
 
 == Member
 
@@ -70,6 +31,45 @@ include::{snippets}/initial-register-member/http-request.adoc[]
 
 .HTTP response
 include::{snippets}/initial-register-member/http-response.adoc[]
+
+=== `POST`: 사용자의 Activity 등록 API
+
+.HTTP request 설명
+include::{snippets}/add-activity/request-fields.adoc[]
+
+.HTTP request
+include::{snippets}/add-activity/http-request.adoc[]
+
+.HTTP response
+include::{snippets}/add-activity/http-response.adoc[]
+
+.HTTP response 설명
+include::{snippets}/add-activity/response-fields.adoc[]
+
+=== `DELETE`: 사용자의 Activity 삭제 API
+
+.HTTP request 설명
+include::{snippets}/delete-activity/request-fields.adoc[]
+
+.HTTP request
+include::{snippets}/delete-activity/http-request.adoc[]
+
+.HTTP response
+include::{snippets}/delete-activity/http-response.adoc[]
+
+.HTTP response 설명
+include::{snippets}/delete-activity/response-fields.adoc[]
+
+=== `GET`: 사용자의 Activity 조회
+
+.HTTP request
+include::{snippets}/find-activity/http-request.adoc[]
+
+.HTTP response
+include::{snippets}/find-activity/http-response.adoc[]
+
+.HTTP response 설명
+include::{snippets}/find-activity/response-fields.adoc[]
 
 === `PUT`: 사용자의 Open Profile URL 업데이트
 

--- a/backend/emm-sale/src/test/java/com/emmsale/member/api/MemberApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/member/api/MemberApiTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.restdocs.payload.RequestFieldsSnippet;
@@ -85,6 +86,7 @@ class MemberApiTest extends MockMvcTestHelper {
 
     //when & then
     mockMvc.perform(post("/members")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isNoContent())
@@ -125,6 +127,7 @@ class MemberApiTest extends MockMvcTestHelper {
 
     //when & then
     mockMvc.perform(post("/members/activities")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isCreated())
@@ -152,6 +155,7 @@ class MemberApiTest extends MockMvcTestHelper {
 
     //when & then
     mockMvc.perform(delete("/members/activities")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isOk())
@@ -210,33 +214,12 @@ class MemberApiTest extends MockMvcTestHelper {
 
     // when
     final ResultActions result = mockMvc.perform(put("/members/open-profile-url")
+        .header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
         .contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(request)));
 
     // then
     result.andExpect(status().isNoContent())
-        .andDo(print())
-        .andDo(document("update-open-profile-url", REQUEST_FIELDS));
-  }
-
-  @Test
-  @DisplayName("사용자의 openProfileUrl이 유효하지 않으면, 400 BAD_REQUEST를 반환한다.")
-  void test_updateOpenProfileUrlWithInvalidUrl() throws Exception {
-    // given
-    final String openProfileUrl = "https://invalid.kakao.com/profile";
-    final OpenProfileUrlRequest request = new OpenProfileUrlRequest(openProfileUrl);
-
-    final RequestFieldsSnippet REQUEST_FIELDS = requestFields(
-        fieldWithPath("openProfileUrl").description("오픈 채팅 url")
-    );
-
-    // when
-    final ResultActions result = mockMvc.perform(put("/members/open-profile-url")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(request)));
-
-    // then
-    result.andExpect(status().isBadRequest())
         .andDo(print())
         .andDo(document("update-open-profile-url", REQUEST_FIELDS));
   }
@@ -254,6 +237,7 @@ class MemberApiTest extends MockMvcTestHelper {
 
     // when
     final ResultActions result = mockMvc.perform(put("/members/description")
+        .header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
         .contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(request)));
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- #366

close #366 

## 📝작업 내용
사용자 활동 생성 및 삭제 api가 RestDocs의 Activity 하위에 있어 이를 Member 하위로 이동
