### PR TITLE
fix: 중복된 활동 id 오류 수정

### DIFF
--- a/backend/emm-sale/src/main/java/com/emmsale/member/api/MemberApi.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/api/MemberApi.java
@@ -5,7 +5,6 @@ import com.emmsale.member.application.MemberQueryService;
 import com.emmsale.member.application.MemberUpdateService;
 import com.emmsale.member.application.dto.DescriptionRequest;
 import com.emmsale.member.application.dto.MemberActivityAddRequest;
-import com.emmsale.member.application.dto.MemberActivityDeleteRequest;
 import com.emmsale.member.application.dto.MemberActivityInitialRequest;
 import com.emmsale.member.application.dto.MemberActivityResponses;
 import com.emmsale.member.application.dto.MemberProfileResponse;
@@ -22,6 +21,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -51,12 +51,10 @@ public class MemberApi {
   }
 
   @DeleteMapping("/members/activities")
-  public ResponseEntity<List<MemberActivityResponses>> deleteActivity(
-      final Member member,
-      @RequestBody final MemberActivityDeleteRequest memberActivityDeleteRequest
-  ) {
+  public ResponseEntity<List<MemberActivityResponses>> deleteActivity(final Member member,
+      @RequestParam("activity-ids") final List<Long> deleteActivityIds) {
     return ResponseEntity.ok(
-        memberActivityService.deleteActivity(member, memberActivityDeleteRequest));
+        memberActivityService.deleteActivity(member, deleteActivityIds));
   }
 
   @GetMapping("/members/{member-id}/activities")

--- a/backend/emm-sale/src/main/java/com/emmsale/member/application/MemberActivityService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/application/MemberActivityService.java
@@ -67,7 +67,7 @@ public class MemberActivityService {
   ) {
     final List<Long> activityIds = memberActivityAddRequest.getActivityIds();
     final List<MemberActivity> memberActivities = memberActivityRepository.findAllByMember(member);
-    if (hasDuplicateId(memberActivities, activityIds)) {
+    if (hasDuplicateId(activityIds)) {
       throw new MemberException(MemberExceptionType.DUPLICATE_ACTIVITY);
     }
     if (isAlreadyExistActivity(memberActivities, activityIds)) {
@@ -87,9 +87,8 @@ public class MemberActivityService {
         );
   }
 
-  private boolean hasDuplicateId(final List<MemberActivity> memberActivities,
-      final List<Long> activityIds) {
-    return new HashSet<>(activityIds).size() != memberActivities.size();
+  private boolean hasDuplicateId(final List<Long> activityIds) {
+    return new HashSet<>(activityIds).size() != activityIds.size();
   }
 
   public List<MemberActivityResponses> deleteActivity(

--- a/backend/emm-sale/src/main/java/com/emmsale/member/application/MemberActivityService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/application/MemberActivityService.java
@@ -4,7 +4,6 @@ import static java.util.stream.Collectors.toList;
 
 import com.emmsale.activity.domain.ActivityRepository;
 import com.emmsale.member.application.dto.MemberActivityAddRequest;
-import com.emmsale.member.application.dto.MemberActivityDeleteRequest;
 import com.emmsale.member.application.dto.MemberActivityInitialRequest;
 import com.emmsale.member.application.dto.MemberActivityResponses;
 import com.emmsale.member.domain.Member;
@@ -93,10 +92,8 @@ public class MemberActivityService {
 
   public List<MemberActivityResponses> deleteActivity(
       final Member member,
-      final MemberActivityDeleteRequest memberActivityDeleteRequest
+      final List<Long> deleteActivityIds
   ) {
-    final List<Long> deleteActivityIds = memberActivityDeleteRequest.getActivityIds();
-
     final List<Long> savedMemberActivityIds =
         memberActivityRepository.findAllByMemberAndActivityIds(member, deleteActivityIds)
             .stream()

--- a/backend/emm-sale/src/test/java/com/emmsale/member/api/MemberApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/member/api/MemberApiTest.java
@@ -21,7 +21,6 @@ import com.emmsale.member.application.MemberQueryService;
 import com.emmsale.member.application.MemberUpdateService;
 import com.emmsale.member.application.dto.DescriptionRequest;
 import com.emmsale.member.application.dto.MemberActivityAddRequest;
-import com.emmsale.member.application.dto.MemberActivityDeleteRequest;
 import com.emmsale.member.application.dto.MemberActivityInitialRequest;
 import com.emmsale.member.application.dto.MemberActivityResponse;
 import com.emmsale.member.application.dto.MemberActivityResponses;
@@ -140,8 +139,7 @@ class MemberApiTest extends MockMvcTestHelper {
   @DisplayName("내 명함에서 활동이력들을 성공적으로 삭제하면, 200 OK를 반환해줄 수 있다.")
   void test_deleteActivity() throws Exception {
     //given
-    final List<Long> activityIds = List.of(1L, 2L);
-    final MemberActivityDeleteRequest request = new MemberActivityDeleteRequest(activityIds);
+    final String activityIds = "1,2";
 
     final List<MemberActivityResponses> memberActivityResponses = List.of(
         new MemberActivityResponses("동아리",
@@ -154,13 +152,11 @@ class MemberApiTest extends MockMvcTestHelper {
         .thenReturn(memberActivityResponses);
 
     //when & then
-    mockMvc.perform(delete("/members/activities")
-            .header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(request)))
+    mockMvc.perform(delete("/members/activities?activity-ids={activityIds}", activityIds)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken"))
         .andExpect(status().isOk())
         .andDo(print())
-        .andDo(document("delete-activity", MEMBER_ACTIVITY_REQUEST_FIELDS,
+        .andDo(document("delete-activity",
             MEMBER_ACTIVITY_RESPONSE_FIELDS));
   }
 

--- a/backend/emm-sale/src/test/java/com/emmsale/member/application/MemberActivityServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/member/application/MemberActivityServiceTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.emmsale.helper.ServiceIntegrationTestHelper;
 import com.emmsale.member.application.dto.MemberActivityAddRequest;
-import com.emmsale.member.application.dto.MemberActivityDeleteRequest;
 import com.emmsale.member.application.dto.MemberActivityInitialRequest;
 import com.emmsale.member.application.dto.MemberActivityResponse;
 import com.emmsale.member.application.dto.MemberActivityResponses;
@@ -165,7 +164,6 @@ class MemberActivityServiceTest extends ServiceIntegrationTestHelper {
     final long savedMemberId = 1L;
 
     final Member member = memberRepository.findById(savedMemberId).get();
-    final MemberActivityDeleteRequest request = new MemberActivityDeleteRequest(deleteActivityIds);
 
     final List<MemberActivityResponses> expected = List.of(
         new MemberActivityResponses("동아리",
@@ -176,7 +174,7 @@ class MemberActivityServiceTest extends ServiceIntegrationTestHelper {
 
     //when
     final List<MemberActivityResponses> actual = memberActivityService.deleteActivity(member,
-        request);
+        deleteActivityIds);
 
     //then
     assertThat(expected)


### PR DESCRIPTION
## #️⃣연관된 이슈
- #377 

close #377

## 📝작업 내용
추가 요청하는 활동 id에 중복된 id가 있을 경우 예외를 발생하는 검증 로직 오류 수정
활동 추가 요청시 activityIds를  body로 받는 것에서 param으로 받는 것으로 수정

## 예상 소요 시간 및 실제 소요 시간
30분 / 30분