### PR TITLE
Feature/#379 내가 작성한 댓글 조회 api 구현

### DIFF
--- a/backend/emm-sale/src/main/java/com/emmsale/comment/api/CommentApi.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/comment/api/CommentApi.java
@@ -3,6 +3,7 @@ package com.emmsale.comment.api;
 import com.emmsale.comment.application.CommentCommandService;
 import com.emmsale.comment.application.CommentQueryService;
 import com.emmsale.comment.application.dto.CommentAddRequest;
+import com.emmsale.comment.application.dto.CommentFindRequest;
 import com.emmsale.comment.application.dto.CommentHierarchyResponse;
 import com.emmsale.comment.application.dto.CommentModifyRequest;
 import com.emmsale.comment.application.dto.CommentResponse;
@@ -16,7 +17,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -36,9 +36,11 @@ public class CommentApi {
   }
 
   @GetMapping("/comments")
-  public List<CommentHierarchyResponse> findAll(@RequestParam final Long eventId,
-      final Member member) {
-    return commentQueryService.findAllCommentsByEventId(eventId, member);
+  public List<CommentHierarchyResponse> findAll(
+      final CommentFindRequest commentFindRequest,
+      final Member member
+  ) {
+    return commentQueryService.findAllComments(commentFindRequest, member);
   }
 
   @GetMapping("/comments/{comment-id}")

--- a/backend/emm-sale/src/main/java/com/emmsale/comment/application/CommentQueryService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/comment/application/CommentQueryService.java
@@ -1,12 +1,17 @@
 package com.emmsale.comment.application;
 
+import static com.emmsale.comment.exception.CommentExceptionType.NOT_EVENT_AND_MEMBER_ID_BOTH_NULL;
+
 import com.emmsale.block.domain.Block;
 import com.emmsale.block.domain.BlockRepository;
+import com.emmsale.comment.application.dto.CommentFindRequest;
 import com.emmsale.comment.application.dto.CommentHierarchyResponse;
 import com.emmsale.comment.domain.Comment;
 import com.emmsale.comment.domain.CommentRepository;
+import com.emmsale.comment.exception.CommentException;
 import com.emmsale.member.domain.Member;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,14 +25,29 @@ public class CommentQueryService {
   private final CommentRepository commentRepository;
   private final BlockRepository blockRepository;
 
-  public List<CommentHierarchyResponse> findAllCommentsByEventId(final Long eventId,
-      final Member member) {
+  public List<CommentHierarchyResponse> findAllComments(
+      final CommentFindRequest commentFindRequest,
+      final Member member
+  ) {
+
+    final Optional<Long> optionalMemberId = commentFindRequest.getOptionalMemberId();
+    final Long eventId = commentFindRequest.getEventId();
+
+    validateBothNull(optionalMemberId, eventId);
 
     final List<Long> blockedMemberIds = getBlockedMemberIds(member);
 
-    final List<Comment> comments = commentRepository.findByEventId(eventId);
+    final List<Comment> comments = optionalMemberId
+        .map(commentRepository::findByMemberId)
+        .orElse(commentRepository.findByEventId(eventId));
 
     return CommentHierarchyResponse.convertAllFrom(comments, blockedMemberIds);
+  }
+
+  private void validateBothNull(final Optional<Long> optionalMemberId, final Long eventId) {
+    if (optionalMemberId.isEmpty() && eventId == null) {
+      throw new CommentException(NOT_EVENT_AND_MEMBER_ID_BOTH_NULL);
+    }
   }
 
   public CommentHierarchyResponse findParentWithChildren(final Long commentId,

--- a/backend/emm-sale/src/main/java/com/emmsale/comment/application/dto/CommentFindRequest.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/comment/application/dto/CommentFindRequest.java
@@ -1,0 +1,21 @@
+package com.emmsale.comment.application.dto;
+
+import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class CommentFindRequest {
+
+  private final Long eventId;
+  @Getter(AccessLevel.PRIVATE)
+  private final Long memberId;
+
+  public Optional<Long> getOptionalMemberId() {
+    return Optional.ofNullable(memberId);
+  }
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/comment/application/dto/CommentHierarchyResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/comment/application/dto/CommentHierarchyResponse.java
@@ -51,8 +51,10 @@ public class CommentHierarchyResponse {
           mapToCommentResponse(entry, parentComment, blockedMemberIds);
 
       result.add(
-          new CommentHierarchyResponse(CommentResponse.from(parentComment, blockedMemberIds),
-              childCommentResponses)
+          new CommentHierarchyResponse(
+              CommentResponse.from(parentComment, blockedMemberIds),
+              childCommentResponses
+          )
       );
     }
 

--- a/backend/emm-sale/src/main/java/com/emmsale/comment/application/dto/CommentResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/comment/application/dto/CommentResponse.java
@@ -1,6 +1,7 @@
 package com.emmsale.comment.application.dto;
 
 import com.emmsale.comment.domain.Comment;
+import com.emmsale.event.domain.Event;
 import com.emmsale.member.domain.Member;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
@@ -21,6 +22,7 @@ public class CommentResponse {
   private Long commentId;
   private Long parentId;
   private Long eventId;
+  private String eventName;
   private boolean isDeleted;
   @JsonFormat(pattern = DATE_TIME_FORMAT)
   private LocalDateTime createdAt;
@@ -32,23 +34,29 @@ public class CommentResponse {
 
   public static CommentResponse from(final Comment comment) {
     final Member member = comment.getMember();
+    final Event event = comment.getEvent();
+
     return new CommentResponse(
         comment.getContent(), comment.getId(),
-        getParentId(comment), comment.getEvent().getId(),
-        comment.isDeleted(), comment.getCreatedAt(),
-        comment.getUpdatedAt(), member.getId(),
-        member.getImageUrl(), member.getName()
+        getParentId(comment), event.getId(),
+        event.getName(), comment.isDeleted(),
+        comment.getCreatedAt(), comment.getUpdatedAt(),
+        member.getId(), member.getImageUrl(),
+        member.getName()
     );
   }
 
   public static CommentResponse from(final Comment comment, final List<Long> blockedMemberIds) {
     final Member member = comment.getMember();
+    final Event event = comment.getEvent();
+
     return new CommentResponse(
         comment.getContentOrHideIfBlockedMember(blockedMemberIds), comment.getId(),
-        getParentId(comment), comment.getEvent().getId(),
-        comment.isDeleted(), comment.getCreatedAt(),
-        comment.getUpdatedAt(), member.getId(),
-        member.getImageUrl(), member.getName()
+        getParentId(comment), event.getId(),
+        event.getName(), comment.isDeleted(),
+        comment.getCreatedAt(), comment.getUpdatedAt(),
+        member.getId(), member.getImageUrl(),
+        member.getName()
     );
   }
 

--- a/backend/emm-sale/src/main/java/com/emmsale/comment/domain/CommentRepository.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/comment/domain/CommentRepository.java
@@ -11,5 +11,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
   List<Comment> findByEventId(@Param("eventId") final Long eventId);
 
   @Query("select c1 From Comment c1 left outer join c1.parent p where c1.id=:id or p.id=:id")
-  List<Comment> findParentAndChildrenByParentId(@Param("id") Long commentId);
+  List<Comment> findParentAndChildrenByParentId(@Param("id") final Long commentId);
+
+  @Query("select c From Comment c join fetch c.member m where m.id = :memberId")
+  List<Comment> findByMemberId(@Param("memberId") final Long memberId);
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/comment/exception/CommentExceptionType.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/comment/exception/CommentExceptionType.java
@@ -23,7 +23,14 @@ public enum CommentExceptionType implements BaseExceptionType {
   FORBIDDEN_MODIFY_DELETED_COMMENT(
       HttpStatus.FORBIDDEN,
       "삭제된 댓글은 수정할 수 없습니다."
-  );
+  ),
+
+  NOT_EVENT_AND_MEMBER_ID_BOTH_NULL(
+      HttpStatus.BAD_REQUEST,
+      "댓글 조회할 때 행사 또는 사용자의 ID 둘 다 NULL일 수는 없습니다"
+  )
+
+  ;
 
   private final HttpStatus httpStatus;
   private final String errorMessage;

--- a/backend/emm-sale/src/test/java/com/emmsale/comment/api/CommentApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/comment/api/CommentApiTest.java
@@ -52,6 +52,7 @@ class CommentApiTest extends MockMvcTestHelper {
       fieldWithPath("commentId").description("저장된 댓글 id"),
       fieldWithPath("parentId").description("대댓글일 경우 부모 댓글 id").optional(),
       fieldWithPath("eventId").description("행사 id"),
+      fieldWithPath("eventName").description("행사 이름"),
       fieldWithPath("createdAt").description("댓글 생성 시간"),
       fieldWithPath("updatedAt").description("댓글 최근 수정 시간"),
       fieldWithPath("deleted").description("댓글 삭제 여부"),
@@ -71,7 +72,7 @@ class CommentApiTest extends MockMvcTestHelper {
     final String content = "내용";
     final CommentAddRequest request = new CommentAddRequest(content, 1L, null);
 
-    final CommentResponse commentResponse = new CommentResponse(content, 2L, 1L, 1L, false,
+    final CommentResponse commentResponse = new CommentResponse(content, 2L, 1L, 1L, "eventName",  false,
         LocalDateTime.now(), LocalDateTime.now(), 1L, "이미지", "이름1");
 
     when(commentCommandService.create(any(), any()))
@@ -102,7 +103,8 @@ class CommentApiTest extends MockMvcTestHelper {
         fieldWithPath("[].parentComment.content").description("댓글 내용"),
         fieldWithPath("[].parentComment.commentId").description("댓글 ID"),
         fieldWithPath("[].parentComment.parentId").description("부모 댓글 ID").optional(),
-        fieldWithPath("[].parentComment.eventId").description("이벤트 ID"),
+        fieldWithPath("[].parentComment.eventId").description("행사 ID"),
+        fieldWithPath("[].parentComment.eventName").description("행사 이름"),
         fieldWithPath("[].parentComment.deleted").description("댓글 삭제 여부"),
         fieldWithPath("[].parentComment.createdAt").description("댓글 생성 날짜"),
         fieldWithPath("[].parentComment.updatedAt").description("댓글 수정 날짜"),
@@ -113,7 +115,8 @@ class CommentApiTest extends MockMvcTestHelper {
         fieldWithPath("[].childComments[].content").description("댓글 내용"),
         fieldWithPath("[].childComments[].commentId").description("댓글 ID"),
         fieldWithPath("[].childComments[].parentId").description("부모 댓글 ID").optional(),
-        fieldWithPath("[].childComments[].eventId").description("이벤트 ID"),
+        fieldWithPath("[].childComments[].eventId").description("행사 ID"),
+        fieldWithPath("[].childComments[].eventName").description("행사 이름"),
         fieldWithPath("[].childComments[].deleted").description("댓글 삭제 여부"),
         fieldWithPath("[].childComments[].createdAt").description("댓글 생성 날짜"),
         fieldWithPath("[].childComments[].updatedAt").description("댓글 수정 날짜"),
@@ -124,17 +127,17 @@ class CommentApiTest extends MockMvcTestHelper {
 
     final List<CommentHierarchyResponse> result = List.of(
         new CommentHierarchyResponse(
-            new CommentResponse("부모댓글2", 4L, null, 1L, false,
+            new CommentResponse("부모댓글2", 4L, null, 1L, "eventName", false,
                 LocalDateTime.now(), LocalDateTime.now(), 1L, "이미지", "이름1"),
             Collections.emptyList()
         ),
         new CommentHierarchyResponse(
-            new CommentResponse("부모댓글1", 5L, null, 1L, false,
+            new CommentResponse("부모댓글1", 5L, null, 1L, "eventName",  false,
                 LocalDateTime.now(), LocalDateTime.now(), 1L, "이미지", "이름1"),
             List.of(
-                new CommentResponse("부모댓글1에 대한 자식댓글1", 2L, 1L, 1L, false,
+                new CommentResponse("부모댓글1에 대한 자식댓글1", 2L, 1L, 1L,  "eventName", false,
                     LocalDateTime.now(), LocalDateTime.now(), 1L, "이미지", "이름1"),
-                new CommentResponse("부모댓글1에 대한 자식댓글2", 3L, 1L, 1L, false,
+                new CommentResponse("부모댓글1에 대한 자식댓글2", 3L, 1L, 1L,  "eventName", false,
                     LocalDateTime.now(), LocalDateTime.now(), 1L, "이미지", "이름1"
                 ))
         ));
@@ -163,7 +166,8 @@ class CommentApiTest extends MockMvcTestHelper {
         fieldWithPath("parentComment.content").description("댓글 내용"),
         fieldWithPath("parentComment.commentId").description("댓글 ID"),
         fieldWithPath("parentComment.parentId").description("부모 댓글 ID").optional(),
-        fieldWithPath("parentComment.eventId").description("이벤트 ID"),
+        fieldWithPath("parentComment.eventId").description("행사 ID"),
+        fieldWithPath("parentComment.eventName").description("행사 제목"),
         fieldWithPath("parentComment.deleted").description("댓글 삭제 여부"),
         fieldWithPath("parentComment.createdAt").description("댓글 생성 날짜"),
         fieldWithPath("parentComment.updatedAt").description("댓글 수정 날짜"),
@@ -174,7 +178,8 @@ class CommentApiTest extends MockMvcTestHelper {
         fieldWithPath("childComments[].content").description("댓글 내용"),
         fieldWithPath("childComments[].commentId").description("댓글 ID"),
         fieldWithPath("childComments[].parentId").description("부모 댓글 ID").optional(),
-        fieldWithPath("childComments[].eventId").description("이벤트 ID"),
+        fieldWithPath("childComments[].eventId").description("행사 ID"),
+        fieldWithPath("childComments[].eventName").description("행사 이름"),
         fieldWithPath("childComments[].deleted").description("댓글 삭제 여부"),
         fieldWithPath("childComments[].createdAt").description("댓글 생성 날짜"),
         fieldWithPath("childComments[].updatedAt").description("댓글 수정 날짜"),
@@ -185,12 +190,12 @@ class CommentApiTest extends MockMvcTestHelper {
 
     final CommentHierarchyResponse result =
         new CommentHierarchyResponse(
-            new CommentResponse("부모댓글1", 5L, null, 1L, false,
+            new CommentResponse("부모댓글1", 5L, null, 1L,  "eventName", false,
                 LocalDateTime.now(), LocalDateTime.now(), 1L, "이미지", "이름1"),
             List.of(
-                new CommentResponse("부모댓글1에 대한 자식댓글1", 2L, 1L, 1L, false,
+                new CommentResponse("부모댓글1에 대한 자식댓글1", 2L, 1L, 1L,  "eventName", false,
                     LocalDateTime.now(), LocalDateTime.now(), 1L, "이미지", "이름1"),
-                new CommentResponse("부모댓글1에 대한 자식댓글2", 3L, 1L, 1L, false,
+                new CommentResponse("부모댓글1에 대한 자식댓글2", 3L, 1L, 1L,  "eventName", false,
                     LocalDateTime.now(), LocalDateTime.now(), 1L, "이미지", "이름1")
             )
         );
@@ -229,7 +234,7 @@ class CommentApiTest extends MockMvcTestHelper {
     final String modifiedContent = "변경된 내용";
     final CommentModifyRequest request = new CommentModifyRequest(modifiedContent);
 
-    final CommentResponse response = new CommentResponse("댓", 5L, null, 1L, false,
+    final CommentResponse response = new CommentResponse("댓", 5L, null, 1L,  "eventName", false,
         LocalDateTime.now(), LocalDateTime.now(), 1L, "이미지", "이름1");
 
     when(commentCommandService.modify(anyLong(), any(), any()))

--- a/backend/emm-sale/src/test/java/com/emmsale/comment/api/CommentApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/comment/api/CommentApiTest.java
@@ -93,7 +93,10 @@ class CommentApiTest extends MockMvcTestHelper {
     final String accessToken = "Bearer AccessToken";
 
     final RequestParametersSnippet requestParam = requestParameters(
-        parameterWithName("eventId").description("댓글을 볼 행사 id"));
+        parameterWithName("eventId").description("댓글을 볼 행사 id(빈 값 가능)").optional(),
+        parameterWithName("memberId").description("조회할 댓글을 작성한 사용자 ID(빈 값 가능) [둘 다 빈 값 X]")
+            .optional()
+    );
 
     final ResponseFieldsSnippet responseFieldsSnippet = responseFields(
         fieldWithPath("[].parentComment.content").description("댓글 내용"),
@@ -123,7 +126,7 @@ class CommentApiTest extends MockMvcTestHelper {
         new CommentHierarchyResponse(
             new CommentResponse("부모댓글2", 4L, null, 1L, false,
                 LocalDateTime.now(), LocalDateTime.now(), 1L, "이미지", "이름1"),
-            Collections.EMPTY_LIST
+            Collections.emptyList()
         ),
         new CommentHierarchyResponse(
             new CommentResponse("부모댓글1", 5L, null, 1L, false,
@@ -136,7 +139,7 @@ class CommentApiTest extends MockMvcTestHelper {
                 ))
         ));
 
-    when(commentQueryService.findAllCommentsByEventId(anyLong(), any()))
+    when(commentQueryService.findAllComments(any(), any()))
         .thenReturn(result);
 
     //when & then

--- a/backend/emm-sale/src/test/java/com/emmsale/comment/domain/CommentRepositoryTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/comment/domain/CommentRepositoryTest.java
@@ -81,4 +81,32 @@ class CommentRepositoryTest {
         List.of(parent.getId(), 자식댓글1.getId(), 자식댓글2.getId())
     );
   }
+
+  @Test
+  @DisplayName("findByMemberId() : 사용자가 작성한 댓글을 조회할 수 있다.")
+  void test_findByMemberId() throws Exception {
+    //given
+    final Event event1 = eventRepository.save(EventFixture.AI_컨퍼런스());
+    final Member member1 = memberRepository.findById(1L).get();
+    final Member member2 = memberRepository.findById(2L).get();
+
+    final Comment comment1 = commentRepository.save(
+        Comment.createRoot(event1, member1, "부모댓글1")
+    );
+    commentRepository.save(Comment.createChild(event1, comment1, member2, "자식댓글1"));
+    final Comment comment2 = commentRepository.save(
+        Comment.createChild(event1, comment1, member1, "자식댓글2")
+    );
+
+    final List<Comment> expected = List.of(comment1, comment2);
+
+    //when
+    final List<Comment> actual = commentRepository.findByMemberId(member1.getId());
+
+    //then
+    assertThat(actual)
+        .usingRecursiveComparison()
+        .ignoringFields("createdAt")
+        .isEqualTo(expected);
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- #379 

## 📝작업 내용

기존에 있던 /comments에는 eventId로만 조회할 수 있었으나,
설정에서 내가 작성한 댓글을 조회하기 위해서 memberId 추가


## 예상 소요 시간 및 실제 소요 시간
5시간 / 3시간
