### PR TITLE
Feature/#387 신고 기능 요구사항 수정 반영

### DIFF
--- a/backend/emm-sale/src/main/java/com/emmsale/report/application/ReportCommandService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/report/application/ReportCommandService.java
@@ -65,8 +65,8 @@ public class ReportCommandService {
   }
 
   private void validateAlreadyExistReport(final ReportCreateRequest reportRequest) {
-    if (reportRepository.existsReportByReporterIdAndReportedId(
-        reportRequest.getReporterId(), reportRequest.getReportedId())) {
+    if (reportRepository.existsReportByReporterIdAndContentIdAndType(
+        reportRequest.getReporterId(), reportRequest.getContentId(), reportRequest.getType())) {
       throw new ReportException(ReportExceptionType.ALREADY_EXIST_REPORT);
     }
   }

--- a/backend/emm-sale/src/main/java/com/emmsale/report/domain/repository/ReportRepository.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/report/domain/repository/ReportRepository.java
@@ -1,10 +1,12 @@
 package com.emmsale.report.domain.repository;
 
 import com.emmsale.report.domain.Report;
+import com.emmsale.report.domain.ReportType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
-  boolean existsReportByReporterIdAndReportedId(final Long reporterId, final Long reportedId);
+  boolean existsReportByReporterIdAndContentIdAndType(final Long reporterId, final Long contentId,
+      final ReportType type);
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#387

## 📝작업 내용
신고 기능 수정 요청사항 반영
- 신고 후 차단 처리 되던 기능에서 차단 기능 제거
- 한 사용자의 여러 게시글을 신고할 수 있도록, member id가 아니라 content id와 coment type으로 중복된 신고요청을 검증하도록 수정


## 예상 소요 시간 및 실제 소요 시간
2시간/3시간

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요