### PR TITLE
Fix#339 태그 알림에서 관심 태그를 불러오지 못하는 버그 수정

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/setting/notificationTagConfig/NotificationTagConfigViewModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/setting/notificationTagConfig/NotificationTagConfigViewModel.kt
@@ -32,19 +32,19 @@ class NotificationTagConfigViewModel(
     }
 
     private fun fetchNotificationTags() {
-        _notificationTags.value = _notificationTags.value.copy(isLoading = true)
+        _notificationTags.value = notificationTags.value.copy(isLoading = true)
 
         viewModelScope.launch {
             val memberId = tokenRepository.getToken()?.uid ?: return@launch
 
             val (eventTags, interestEventTagIds) = awaitAll(
                 getEventTagsAsync(),
-                getInterestEventTagIdsAsync(memberId),
+                getInterestEventTagsAsync(memberId),
             )
 
             _notificationTags.value = NotificationTagsConfigUiState.from(
                 eventTags = eventTags.filterIsInstance(EventTag::class.java),
-                interestTagIds = interestEventTagIds.filterIsInstance(Long::class.java),
+                interestEventTags = interestEventTagIds.filterIsInstance(EventTag::class.java),
             )
         }
     }
@@ -67,10 +67,10 @@ class NotificationTagConfigViewModel(
         )
     }
 
-    private suspend fun getInterestEventTagIdsAsync(memberId: Long): Deferred<List<Long>> =
+    private suspend fun getInterestEventTagsAsync(memberId: Long): Deferred<List<EventTag>> =
         viewModelScope.async {
             when (val result = eventTagRepository.getInterestEventTags(memberId)) {
-                is ApiSuccess -> result.data.map(EventTag::id)
+                is ApiSuccess -> result.data
                 is ApiError, is ApiException -> {
                     changeToInterestingTagFetchingErrorState()
                     emptyList()

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/setting/notificationTagConfig/uistate/NotificationTagsConfigUiState.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/setting/notificationTagConfig/uistate/NotificationTagsConfigUiState.kt
@@ -32,9 +32,11 @@ data class NotificationTagsConfigUiState(
     companion object {
         fun from(
             eventTags: List<EventTag>,
-            interestTagIds: List<Long>,
-        ): NotificationTagsConfigUiState =
-            NotificationTagsConfigUiState(
+            interestEventTags: List<EventTag>,
+        ): NotificationTagsConfigUiState {
+            val interestTagIds = interestEventTags.map(EventTag::id)
+
+            return NotificationTagsConfigUiState(
                 conferenceTags = eventTags.map { eventTag ->
                     NotificationTagConfigUiState.from(
                         eventTag = eventTag,
@@ -43,5 +45,6 @@ data class NotificationTagsConfigUiState(
                 },
                 isTagFetchingSuccess = true,
             )
+        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
>  ex) #399

## 📝작업 내용
> 태그 알림 화면에서 관심 태그 목록을 변환하지 못하는 버그를 수정했습니다.

### 스크린샷 (선택)


## 예상 소요 시간 및 실제 소요 시간
> 30분/15분

## 💬리뷰 요구사항(선택)

> 기존에 이야기 되었던 것처럼, 오류가 없는 이상 시간 부족으로 인해 바로 merge하도록 하겠습니다.