### PR TITLE
Fix/#415 작성한 댓글의 내용이 아닌 부모의 댓글이 조회되는 현상 해결

### DIFF
--- a/backend/emm-sale/src/docs/asciidoc/index.adoc
+++ b/backend/emm-sale/src/docs/asciidoc/index.adoc
@@ -289,16 +289,16 @@ include::{snippets}/delete-event/http-response.adoc[]
 === `GET` : 댓글 모두 조회
 
 .HTTP request 설명
-include::{snippets}/get-comment/request-parameters.adoc[]
+include::{snippets}/get-comments/request-parameters.adoc[]
 
 .HTTP request
-include::{snippets}/get-comment/http-request.adoc[]
+include::{snippets}/get-comments/http-request.adoc[]
 
 .HTTP response
-include::{snippets}/get-comment/http-response.adoc[]
+include::{snippets}/get-comments/http-response.adoc[]
 
 .HTTP response 설명
-include::{snippets}/get-comment/response-fields.adoc[]
+include::{snippets}/get-comments/response-fields.adoc[]
 
 === `GET` : 특정 댓글 조회(대댓글 있을 경우 같이 조회)
 

--- a/backend/emm-sale/src/main/java/com/emmsale/comment/application/CommentQueryService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/comment/application/CommentQueryService.java
@@ -55,8 +55,12 @@ public class CommentQueryService {
 
     final List<Long> blockedMemberIds = getBlockedMemberIds(member);
 
-    final List<Comment> parentWithChildrenComments
-        = commentRepository.findParentAndChildrenByParentId(commentId);
+    final Comment comment = commentRepository.findById(commentId)
+        .orElseThrow();
+
+    final List<Comment> parentWithChildrenComments = comment.getParent()
+        .map(it -> commentRepository.findParentAndChildrenByParentId(it.getId()))
+        .orElseGet(() -> commentRepository.findParentAndChildrenByParentId(commentId));
 
     return CommentHierarchyResponse.from(parentWithChildrenComments, blockedMemberIds);
   }

--- a/backend/emm-sale/src/main/java/com/emmsale/comment/application/CommentQueryService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/comment/application/CommentQueryService.java
@@ -1,6 +1,7 @@
 package com.emmsale.comment.application;
 
 import static com.emmsale.comment.exception.CommentExceptionType.NOT_EVENT_AND_MEMBER_ID_BOTH_NULL;
+import static com.emmsale.comment.exception.CommentExceptionType.NOT_FOUND_COMMENT;
 
 import com.emmsale.block.domain.Block;
 import com.emmsale.block.domain.BlockRepository;
@@ -56,7 +57,7 @@ public class CommentQueryService {
     final List<Long> blockedMemberIds = getBlockedMemberIds(member);
 
     final Comment comment = commentRepository.findById(commentId)
-        .orElseThrow();
+        .orElseThrow(() -> new CommentException(NOT_FOUND_COMMENT));
 
     final List<Comment> parentWithChildrenComments = comment.getParent()
         .map(it -> commentRepository.findParentAndChildrenByParentId(it.getId()))

--- a/backend/emm-sale/src/main/java/com/emmsale/comment/event/UpdateNotificationEvent.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/comment/event/UpdateNotificationEvent.java
@@ -19,7 +19,7 @@ public class UpdateNotificationEvent {
   public static UpdateNotificationEvent from(final Comment comment) {
     return new UpdateNotificationEvent(
         comment.getMember().getId(),
-        comment.getParentIdOrSelfId(),
+        comment.getId(),
         UPDATE_NOTIFICATION_COMMENT_TYPE,
         LocalDateTime.now()
     );

--- a/backend/emm-sale/src/main/java/com/emmsale/notification/application/dto/UpdateNotificationResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/notification/application/dto/UpdateNotificationResponse.java
@@ -34,7 +34,9 @@ public class UpdateNotificationResponse {
         new CommentTypeNotification(
             comment.getContent(),
             comment.getEvent().getName(),
-            comment.getMember().getImageUrl()
+            comment.getMember().getImageUrl(),
+            comment.getParentIdOrSelfId(),
+            comment.getEvent().getId()
         )
     );
   }
@@ -50,10 +52,6 @@ public class UpdateNotificationResponse {
     );
   }
 
-  private boolean getIsRead() {
-    return isRead;
-  }
-
   @RequiredArgsConstructor
   @Getter
   public static class CommentTypeNotification {
@@ -61,5 +59,11 @@ public class UpdateNotificationResponse {
     private final String content;
     private final String eventName;
     private final String commenterImageUrl;
+    private final Long parentId;
+    private final Long eventId;
+  }
+
+  private boolean getIsRead() {
+    return isRead;
   }
 }

--- a/backend/emm-sale/src/test/java/com/emmsale/comment/api/CommentApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/comment/api/CommentApiTest.java
@@ -151,7 +151,7 @@ class CommentApiTest extends MockMvcTestHelper {
             .header("Authorization", accessToken))
         .andExpect(status().isOk())
         .andDo(print())
-        .andDo(document("get-comment", requestParam, responseFieldsSnippet));
+        .andDo(document("get-comments", requestParam, responseFieldsSnippet));
   }
 
   @Test
@@ -159,7 +159,7 @@ class CommentApiTest extends MockMvcTestHelper {
   void test_findChildren() throws Exception {
     //given
     final PathParametersSnippet pathParams = pathParameters(
-        parameterWithName("comment-id").description("부모 ID")
+        parameterWithName("comment-id").description("댓글 ID")
     );
 
     final ResponseFieldsSnippet responseFields = responseFields(

--- a/backend/emm-sale/src/test/java/com/emmsale/comment/application/CommentCommandServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/comment/application/CommentCommandServiceTest.java
@@ -151,10 +151,12 @@ class CommentCommandServiceTest extends ServiceIntegrationTestHelper {
   }
 
   /**
-   * 1 ㄴ2  (1에게 알림) ㄴ3  (1,2에게 알림)
+   * 1
+   * ㄴ2  (1에게 알림)
+   * ㄴ3  (1,2에게 알림)
    * <p>
-   * <p>
-   * 새로운 대댓글 ㄴ2  (1,3에게 알림)
+   * 새로운 대댓글
+   * ㄴ2  (1,3에게 알림)
    */
   @Test
   @DisplayName("create() : 자신이 작성한 댓글, 대댓글들 중에서 다른 사람이 댓글을 작성할 경우 알림이 온다.")

--- a/backend/emm-sale/src/test/java/com/emmsale/comment/application/CommentQueryServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/comment/application/CommentQueryServiceTest.java
@@ -128,8 +128,8 @@ class CommentQueryServiceTest extends ServiceIntegrationTestHelper {
   }
 
   @Test
-  @DisplayName("findParentWithChildren() : 부모 댓글에 있는 자식 댓글들을 모두 조회할 수 있다.")
-  void test_findChildrenComments() throws Exception {
+  @DisplayName("findParentWithChildren() : 부모 댓글이라면 해당 부모 댓글과 그 자식 댓글들을 모두 조회할 수 있다.")
+  void test_findChildrenComments_parentId() throws Exception {
     //given
     final Comment 자식댓글2 = commentRepository.save(
         Comment.createChild(event, 부모_댓글1, member, "자식댓글2"));
@@ -148,6 +148,34 @@ class CommentQueryServiceTest extends ServiceIntegrationTestHelper {
     //when
     final CommentHierarchyResponse actual =
         commentQueryService.findParentWithChildren(부모_댓글1.getId(), member);
+
+    //then
+    assertThat(actual)
+        .usingRecursiveComparison()
+        .isEqualTo(expected);
+  }
+
+  @Test
+  @DisplayName("findParentWithChildren() : 자식 댓글이라면 해당 부모 댓글과 그 자식 댓글들을 모두 조회할 수 있다.")
+  void test_findChildrenComments_childId() throws Exception {
+    //given
+    final Comment 자식댓글2 = commentRepository.save(
+        Comment.createChild(event, 부모_댓글1, member, "자식댓글2"));
+    final Comment 자식댓글1 = commentRepository.save(
+        Comment.createChild(event, 부모_댓글1, member, "자식댓글1"));
+
+    final CommentHierarchyResponse expected =
+        new CommentHierarchyResponse(
+            CommentResponse.from(부모_댓글1),
+            List.of(
+                CommentResponse.from(자식댓글2),
+                CommentResponse.from(자식댓글1)
+            )
+        );
+
+    //when
+    final CommentHierarchyResponse actual =
+        commentQueryService.findParentWithChildren(자식댓글1.getId(), member);
 
     //then
     assertThat(actual)

--- a/backend/emm-sale/src/test/java/com/emmsale/notification/api/UpdateNotificationApiTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/notification/api/UpdateNotificationApiTest.java
@@ -66,6 +66,10 @@ class UpdateNotificationApiTest extends MockMvcTestHelper {
             .optional(),
         fieldWithPath("[].commentTypeNotification.eventName").description("(댓글 알림일 경우)이벤트 이름")
             .optional(),
+        fieldWithPath("[].commentTypeNotification.parentId").description("(댓글 알림일 경우)부모 댓글 ID")
+            .optional(),
+        fieldWithPath("[].commentTypeNotification.eventId").description("(댓글 알림일 경우)이벤트 ID")
+            .optional(),
         fieldWithPath("[].commentTypeNotification.commenterImageUrl").description(
                 "(댓글 알림일 경우) 댓글 작성자 이미지 Url")
             .optional()
@@ -74,7 +78,9 @@ class UpdateNotificationApiTest extends MockMvcTestHelper {
     final CommentTypeNotification commentTypeNotification = new CommentTypeNotification(
         "대댓글 내용",
         "이벤트 이름",
-        "대댓글 단 사용자의 이미지 URL"
+        "대댓글 단 사용자의 이미지 URL",
+        3L,
+        5L
     );
 
     final List<UpdateNotificationResponse> responses = List.of(

--- a/backend/emm-sale/src/test/java/com/emmsale/notification/application/UpdateNotificationQueryServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/notification/application/UpdateNotificationQueryServiceTest.java
@@ -87,7 +87,9 @@ class UpdateNotificationQueryServiceTest extends ServiceIntegrationTestHelper {
             new CommentTypeNotification(
                 comment.getContent(),
                 comment.getEvent().getName(),
-                comment.getMember().getImageUrl()
+                comment.getMember().getImageUrl(),
+                comment.getParentIdOrSelfId(),
+                comment.getEvent().getId()
             )
         )
     );


### PR DESCRIPTION
## #️⃣연관된 이슈
- #415 

## 📝작업 내용

알림 보관함 조회 시 응답 데이터 변경
특정 댓글 조회 시 부모 ID가 아닌 댓글 ID로도 조회 가능하도록 수정
댓글 알림에서 redirectId를 생성된 댓글 ID로 수정


## 예상 소요 시간 및 실제 소요 시간
3시간 / 3시간
