### PR TITLE
fix: CommentTypeNotificationApiModel 프로퍼티 기본 값 설정

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/notification/updated/dto/CommentTypeNotificationApiModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/notification/updated/dto/CommentTypeNotificationApiModel.kt
@@ -12,7 +12,7 @@ data class CommentTypeNotificationApiModel(
     @SerialName("commenterImageUrl")
     val commentProfileImageUrl: String,
     @SerialName("parentId")
-    val parentId: Long,
+    val parentId: Long = -1L,
     @SerialName("eventId")
-    val eventId: Long,
+    val eventId: Long = -1L,
 )


### PR DESCRIPTION
## #️⃣연관된 이슈
> #432

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
CommentTypeNotificationApiModel의 parentId가 null인 경우 아예 댓글 알림 정보를 보여주지 않는 버그를 해결했습니다.
kotlinx-serialization을 사용 중이기 때문에 기본 값을 -1로 설정하여 댓글 자체는 보일 수 있게 변경하였습니다.
대신, 알림을 클릭했을 때 대댓글 화면으로 리다이렉트만 불가능하도록 하였습니다.

### 스크린샷 (선택)


## 예상 소요 시간 및 실제 소요 시간
> 30분 / 20분


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요