### PR TITLE
Fix/#464 관심 행사 알림 태그 수정 안 되는 버그 수정

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/eventTag/remote/dto/InterestEventTagUpdateRequestApiModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/eventTag/remote/dto/InterestEventTagUpdateRequestApiModel.kt
@@ -1,5 +1,10 @@
 package com.emmsale.data.eventTag.remote.dto
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class InterestEventTagUpdateRequestApiModel(
+    @SerialName("tagIds")
     val interestEventTagIds: List<Long>,
 )

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/main/setting/notification/NotificationConfigViewModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/main/setting/notification/NotificationConfigViewModel.kt
@@ -76,7 +76,7 @@ class NotificationConfigViewModel(
     fun removeInterestTagById(eventId: Long) {
         viewModelScope.launch {
             val removedInterestEventTags = notificationTags.value.conferenceTags
-                .filterNot { it.id != eventId }
+                .filterNot { it.id == eventId }
                 .map { EventTag(id = it.id, name = it.tagName) }
 
             when (eventTagRepository.updateInterestEventTags(removedInterestEventTags)) {

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/main/setting/notificationTagConfig/NotificationTagConfigViewModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/main/setting/notificationTagConfig/NotificationTagConfigViewModel.kt
@@ -96,6 +96,7 @@ class NotificationTagConfigViewModel(
             when (eventTagRepository.updateInterestEventTags(interestEventTags)) {
                 is ApiSuccess -> {
                     _notificationTags.value = notificationTags.value.copy(
+                        isTagFetchingSuccess = false,
                         isInterestTagsUpdateSuccess = true,
                     )
                     logInterestTags(interestEventTags.map(EventTag::name))


### PR DESCRIPTION
## #️⃣연관된 이슈
>  #464

## 📝작업 내용
선택된 태그 제외하고 나머지 태그들이 삭제되는 버그 수정
태그 알림 수정시 화면 종료 안 되는 버그 수정
태그 알림 목록이 변경되지 않는 버그 수정 buna 9 minutes ago

### 스크린샷 (선택)
<img width="362" alt="스크린샷 2023-08-18 오전 11 40 12" src="https://github.com/woowacourse-teams/2023-emmsale/assets/56534241/75051302-e376-4c44-b46b-e16cf3acd729">

<img width="363" alt="스크린샷 2023-08-18 오전 11 40 27" src="https://github.com/woowacourse-teams/2023-emmsale/assets/56534241/336f06ad-e734-4b9a-9b44-7ad850a51b82">

<img width="296" alt="스크린샷 2023-08-18 오전 11 40 37" src="https://github.com/woowacourse-teams/2023-emmsale/assets/56534241/2564fbe7-2ab4-4448-917b-690a6afb342f">

<img width="370" alt="스크린샷 2023-08-18 오전 11 40 45" src="https://github.com/woowacourse-teams/2023-emmsale/assets/56534241/cafaf952-166f-4fc0-bfdf-0ad62502a65c">

## 예상 소요 시간 및 실제 소요 시간
20분 / 20분


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요