### PR TITLE
Fix/#489 컨퍼런스 날짜 필터 제거해도 화면 갱신되지 않는 버그

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/main/event/competition/CompetitionViewModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/main/event/competition/CompetitionViewModel.kt
@@ -55,12 +55,11 @@ class CompetitionViewModel(
         viewModelScope.launch {
             _competitions.value = _competitions.value.copy(isLoading = true)
             when (val eventsResult = getCompetitions(statuses, tags, startDate, endDate)) {
-                is ApiSuccess ->
-                    _competitions.value = _competitions.value.copy(
-                        competitions = eventsResult.data.map(CompetitionUiState::from),
-                        isLoading = false,
-                        isError = false,
-                    )
+                is ApiSuccess -> _competitions.value = _competitions.value.copy(
+                    competitions = eventsResult.data.map(CompetitionUiState::from),
+                    isLoading = false,
+                    isError = false,
+                )
 
                 is ApiError, is ApiException -> _competitions.value = _competitions.value.copy(
                     isError = true,
@@ -82,8 +81,8 @@ class CompetitionViewModel(
         endDate = endDate,
     )
 
-    private fun fetchFilteredCompetitions(filterOption: CompetitionSelectedFilteringUiState) {
-        with(filterOption) {
+    private fun fetchFilteredCompetitions() {
+        with(selectedFilter.value) {
             fetchFilteredCompetitions(
                 selectedStatusFilteringOptionIds,
                 selectedTagFilteringOptionIds,
@@ -146,14 +145,13 @@ class CompetitionViewModel(
         }
 
     fun removeFilteringOptionBy(filterOptionId: Long) {
-        val newSelectedFilter = _selectedFilter.value.removeFilteringOptionBy(filterOptionId)
-        _selectedFilter.value = newSelectedFilter
-
-        fetchFilteredCompetitions(newSelectedFilter)
+        _selectedFilter.value = selectedFilter.value.removeFilteringOptionBy(filterOptionId)
+        fetchFilteredCompetitions()
     }
 
     fun removeDurationFilteringOption() {
         _selectedFilter.value = _selectedFilter.value.clearSelectedDate()
+        fetchFilteredCompetitions()
     }
 
     companion object {

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/main/event/conference/ConferenceViewModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/main/event/conference/ConferenceViewModel.kt
@@ -82,17 +82,6 @@ class ConferenceViewModel(
         endDate = endDate,
     )
 
-    private fun fetchFilteredConferences(filterOption: ConferenceSelectedFilteringUiState) {
-        with(filterOption) {
-            fetchFilteredConferences(
-                selectedStatusFilteringOptionIds,
-                selectedTagFilteringOptionIds,
-                startDateFilteringOption?.date,
-                endDateFilteringOption?.date,
-            )
-        }
-    }
-
     fun fetchFilteredConferences(
         statusFilterIds: Array<Long>,
         tagFilterIds: Array<Long>,
@@ -148,14 +137,24 @@ class ConferenceViewModel(
         }
 
     fun removeFilteringOptionBy(filterOptionId: Long) {
-        val newSelectedFilter = _selectedFilter.value.removeFilteringOptionBy(filterOptionId)
-        _selectedFilter.value = newSelectedFilter
-
-        fetchFilteredConferences(newSelectedFilter)
+        _selectedFilter.value = selectedFilter.value.removeFilteringOptionBy(filterOptionId)
+        fetchFilteredConferences()
     }
 
     fun removeDurationFilteringOption() {
-        _selectedFilter.value = _selectedFilter.value.clearSelectedDate()
+        _selectedFilter.value = selectedFilter.value.clearSelectedDate()
+        fetchFilteredConferences()
+    }
+
+    private fun fetchFilteredConferences() {
+        with(selectedFilter.value) {
+            fetchFilteredConferences(
+                selectedStatusFilteringOptionIds,
+                selectedTagFilteringOptionIds,
+                startDateFilteringOption?.date,
+                endDateFilteringOption?.date,
+            )
+        }
     }
 
     companion object {

--- a/android/2023-emmsale/app/src/main/res/layout/fragment_primary_notification.xml
+++ b/android/2023-emmsale/app/src/main/res/layout/fragment_primary_notification.xml
@@ -50,7 +50,8 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            bind:viewModel="@{viewModel}" />
+            bind:viewModel="@{viewModel}"
+            tools:visibility="gone" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## #️⃣연관된 이슈
#489

## 📝작업 내용
> 컨퍼런스와 대회에서 `날짜 필터`를 제거해도 화면이 갱신되지 않는 버그를 수정했습니다.

### 스크린샷 (선택)


## 예상 소요 시간 및 실제 소요 시간
> 30분 / 10분


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요