### PR TITLE
Refactor/#492 댓글 행사 알림 삭제 시 쿼리 최적화

### DIFF
--- a/backend/emm-sale/src/main/java/com/emmsale/comment/application/CommentCommandService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/comment/application/CommentCommandService.java
@@ -4,14 +4,12 @@ import static com.emmsale.comment.exception.CommentExceptionType.FORBIDDEN_DELET
 import static com.emmsale.comment.exception.CommentExceptionType.FORBIDDEN_MODIFY_COMMENT;
 import static com.emmsale.comment.exception.CommentExceptionType.FORBIDDEN_MODIFY_DELETED_COMMENT;
 import static com.emmsale.comment.exception.CommentExceptionType.NOT_FOUND_COMMENT;
-import static java.util.stream.Collectors.toMap;
 
 import com.emmsale.comment.application.dto.CommentAddRequest;
 import com.emmsale.comment.application.dto.CommentModifyRequest;
 import com.emmsale.comment.application.dto.CommentResponse;
 import com.emmsale.comment.domain.Comment;
 import com.emmsale.comment.domain.CommentRepository;
-import com.emmsale.comment.event.UpdateNotificationEvent;
 import com.emmsale.comment.exception.CommentException;
 import com.emmsale.comment.exception.CommentExceptionType;
 import com.emmsale.event.domain.Event;
@@ -20,11 +18,6 @@ import com.emmsale.event.exception.EventException;
 import com.emmsale.event.exception.EventExceptionType;
 import com.emmsale.event_publisher.EventPublisher;
 import com.emmsale.member.domain.Member;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -57,42 +50,9 @@ public class CommentCommandService {
 
     final Comment savedComment = commentRepository.save(comment);
 
-    publishNotificationExceptMe(member, savedComment);
+    eventPublisher.publish(savedComment, member);
 
     return CommentResponse.from(savedComment);
-  }
-
-  private void publishNotificationExceptMe(final Member member, final Comment savedComment) {
-    final Set<Comment> notificationCommentCandidates = savedComment.getParent()
-        .map(parent -> excludeMyComments(member, parent))
-        .orElse(Collections.emptySet());
-
-    notificationCommentCandidates.stream()
-        .map(it -> UpdateNotificationEvent.from(it, savedComment.getId()))
-        .forEach(eventPublisher::publish);
-  }
-
-  private Set<Comment> excludeMyComments(final Member member, final Comment parent) {
-
-    final List<Comment> comments =
-        commentRepository.findParentAndChildrenByParentId(parent.getId());
-
-    return new HashSet<>(removeDuplicatedCommentsWriter(member, comments));
-  }
-
-  private Collection<Comment> removeDuplicatedCommentsWriter(
-      final Member loginMember,
-      final List<Comment> comments
-  ) {
-    return comments.stream()
-        .filter(it -> it.isNotMyComment(loginMember))
-        .filter(Comment::isNotDeleted)
-        .collect(toMap(
-            comment -> comment.getMember().getId(),
-            comment -> comment,
-            (existed, replaced) -> existed)
-        )
-        .values();
   }
 
   private Comment findSavedComment(final Long commentId) {

--- a/backend/emm-sale/src/main/java/com/emmsale/comment/domain/CommentRepository.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/comment/domain/CommentRepository.java
@@ -10,7 +10,10 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
   @Query("select c From Comment c inner join Event e on c.event.id = e.id where e.id = :eventId")
   List<Comment> findByEventId(@Param("eventId") final Long eventId);
 
-  @Query("select c1 From Comment c1 left outer join c1.parent p where c1.id=:id or p.id=:id")
+  @Query("select c1 From Comment c1 "
+      + "left outer join fetch c1.parent p "
+      + "join fetch c1.member "
+      + "where c1.id=:id or p.id=:id")
   List<Comment> findParentAndChildrenByParentId(@Param("id") final Long commentId);
 
   @Query("select c From Comment c join fetch c.member m where m.id = :memberId")

--- a/backend/emm-sale/src/main/java/com/emmsale/comment/event/UpdateNotificationEvent.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/comment/event/UpdateNotificationEvent.java
@@ -1,6 +1,7 @@
 package com.emmsale.comment.event;
 
 import com.emmsale.comment.domain.Comment;
+import com.emmsale.event.domain.Event;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -10,17 +11,27 @@ import lombok.RequiredArgsConstructor;
 public class UpdateNotificationEvent {
 
   private static final String UPDATE_NOTIFICATION_COMMENT_TYPE = "comment";
+  private static final String UPDATE_NOTIFICATION_EVENT_TYPE = "event";
 
   private final Long receiverId;
   private final Long redirectId;
   private final String updateNotificationType;
   private final LocalDateTime createdAt;
 
-  public static UpdateNotificationEvent from(final Comment comment, final Long redirectId) {
+  public static UpdateNotificationEvent of(final Comment comment, final Long redirectId) {
     return new UpdateNotificationEvent(
         comment.getMember().getId(),
         redirectId,
         UPDATE_NOTIFICATION_COMMENT_TYPE,
+        LocalDateTime.now()
+    );
+  }
+
+  public static UpdateNotificationEvent of(final Event event, final Long receiverId) {
+    return new UpdateNotificationEvent(
+        receiverId,
+        event.getId(),
+        UPDATE_NOTIFICATION_EVENT_TYPE,
         LocalDateTime.now()
     );
   }

--- a/backend/emm-sale/src/main/java/com/emmsale/config/NPlus1DetectorConfig.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/config/NPlus1DetectorConfig.java
@@ -1,0 +1,14 @@
+package com.emmsale.config;
+
+import com.support.NPlus1DetectorAop;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class NPlus1DetectorConfig {
+
+  @Bean
+  public NPlus1DetectorAop loggingFormAop() {
+    return new NPlus1DetectorAop();
+  }
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/event_publisher/EventPublisher.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event_publisher/EventPublisher.java
@@ -7,7 +7,6 @@ import com.emmsale.event.domain.Event;
 import com.emmsale.member.domain.InterestTagRepository;
 import com.emmsale.member.domain.Member;
 import com.emmsale.member.domain.MemberRepository;
-import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -21,7 +20,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class EventPublisher {
 
-  private static final String UPDATE_NOTIFICATION_EVENT_TYPE = "event";
 
   private final ApplicationEventPublisher applicationEventPublisher;
   private final InterestTagRepository interestTagRepository;
@@ -34,7 +32,7 @@ public class EventPublisher {
         .orElse(Collections.emptySet());
 
     notificationCommentCandidates.stream()
-        .map(it -> UpdateNotificationEvent.from(it, trigger.getId()))
+        .map(it -> UpdateNotificationEvent.of(it, trigger.getId()))
         .forEach(applicationEventPublisher::publishEvent);
   }
 
@@ -72,15 +70,10 @@ public class EventPublisher {
   }
 
   private void publishEvent(final Event event, final List<Member> members) {
-    for (Member member : members) {
-      final UpdateNotificationEvent updateNotificationEvent = new UpdateNotificationEvent(
-          member.getId(),
-          event.getId(),
-          UPDATE_NOTIFICATION_EVENT_TYPE,
-          LocalDateTime.now()
-      );
-
-      applicationEventPublisher.publishEvent(updateNotificationEvent);
-    }
+    members.forEach(
+        it -> applicationEventPublisher.publishEvent(
+            UpdateNotificationEvent.of(event, it.getId())
+        )
+    );
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/event_publisher/EventPublisher.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event_publisher/EventPublisher.java
@@ -28,10 +28,6 @@ public class EventPublisher {
   private final MemberRepository memberRepository;
   private final CommentRepository commentRepository;
 
-  public void publish(final UpdateNotificationEvent event) {
-    applicationEventPublisher.publishEvent(event);
-  }
-
   public void publish(final Comment trigger, final Member loginMember) {
     final Set<Comment> notificationCommentCandidates = trigger.getParent()
         .map(parent -> findRelatedCommentsExcludingLoginMember(loginMember, parent))
@@ -58,7 +54,6 @@ public class EventPublisher {
             .values()
     );
   }
-
 
   public void publish(final Event event) {
     final List<Long> tagIds = event.getTags()

--- a/backend/emm-sale/src/main/java/com/emmsale/event_publisher/EventPublisher.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event_publisher/EventPublisher.java
@@ -2,7 +2,6 @@ package com.emmsale.event_publisher;
 
 import com.emmsale.comment.domain.Comment;
 import com.emmsale.comment.domain.CommentRepository;
-import com.emmsale.comment.event.UpdateNotificationEvent;
 import com.emmsale.event.domain.Event;
 import com.emmsale.member.domain.InterestTagRepository;
 import com.emmsale.member.domain.Member;

--- a/backend/emm-sale/src/main/java/com/emmsale/event_publisher/EventPublisher.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event_publisher/EventPublisher.java
@@ -1,11 +1,15 @@
 package com.emmsale.event_publisher;
 
+import com.emmsale.comment.domain.Comment;
+import com.emmsale.comment.domain.CommentRepository;
 import com.emmsale.comment.event.UpdateNotificationEvent;
 import com.emmsale.event.domain.Event;
 import com.emmsale.member.domain.InterestTagRepository;
 import com.emmsale.member.domain.Member;
 import com.emmsale.member.domain.MemberRepository;
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -22,10 +26,39 @@ public class EventPublisher {
   private final ApplicationEventPublisher applicationEventPublisher;
   private final InterestTagRepository interestTagRepository;
   private final MemberRepository memberRepository;
+  private final CommentRepository commentRepository;
 
   public void publish(final UpdateNotificationEvent event) {
     applicationEventPublisher.publishEvent(event);
   }
+
+  public void publish(final Comment trigger, final Member loginMember) {
+    final Set<Comment> notificationCommentCandidates = trigger.getParent()
+        .map(parent -> findRelatedCommentsExcludingLoginMember(loginMember, parent))
+        .orElse(Collections.emptySet());
+
+    notificationCommentCandidates.stream()
+        .map(it -> UpdateNotificationEvent.from(it, trigger.getId()))
+        .forEach(applicationEventPublisher::publishEvent);
+  }
+
+  private Set<Comment> findRelatedCommentsExcludingLoginMember(
+      final Member loginMember,
+      final Comment parent
+  ) {
+    return new HashSet<>(
+        commentRepository.findParentAndChildrenByParentId(parent.getId())
+            .stream()
+            .filter(it -> it.isNotMyComment(loginMember))
+            .filter(Comment::isNotDeleted)
+            .collect(Collectors.toMap(
+                comment -> comment.getMember().getId(),
+                comment -> comment, (existed, replaces) -> existed)
+            )
+            .values()
+    );
+  }
+
 
   public void publish(final Event event) {
     final List<Long> tagIds = event.getTags()

--- a/backend/emm-sale/src/main/java/com/emmsale/event_publisher/UpdateNotificationEvent.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event_publisher/UpdateNotificationEvent.java
@@ -1,4 +1,4 @@
-package com.emmsale.comment.event;
+package com.emmsale.event_publisher;
 
 import com.emmsale.comment.domain.Comment;
 import com.emmsale.event.domain.Event;

--- a/backend/emm-sale/src/main/java/com/emmsale/notification/application/NotificationEventListener.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/notification/application/NotificationEventListener.java
@@ -5,9 +5,13 @@ import com.emmsale.notification.domain.UpdateNotification;
 import com.emmsale.notification.domain.UpdateNotificationRepository;
 import com.emmsale.notification.domain.UpdateNotificationType;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class NotificationEventListener {
@@ -15,7 +19,9 @@ public class NotificationEventListener {
   private final UpdateNotificationRepository updateNotificationRepository;
   private final FirebaseCloudMessageClient firebaseCloudMessageClient;
 
-  @EventListener
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  @TransactionalEventListener
   public void createUpdateNotification(final UpdateNotificationEvent updateNotificationEvent) {
     final UpdateNotification updateNotification = new UpdateNotification(
         updateNotificationEvent.getReceiverId(),
@@ -27,6 +33,10 @@ public class NotificationEventListener {
     final UpdateNotification savedNotification =
         updateNotificationRepository.save(updateNotification);
 
-    firebaseCloudMessageClient.sendMessageTo(savedNotification);
+    try {
+      firebaseCloudMessageClient.sendMessageTo(savedNotification);
+    } catch (Exception e) {
+      log.error("파이어베이스 관련 에러, 알림 재요청 필요, {}", e.getMessage(), e);
+    }
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/notification/application/NotificationEventListener.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/notification/application/NotificationEventListener.java
@@ -1,6 +1,6 @@
 package com.emmsale.notification.application;
 
-import com.emmsale.comment.event.UpdateNotificationEvent;
+import com.emmsale.event_publisher.UpdateNotificationEvent;
 import com.emmsale.notification.domain.UpdateNotification;
 import com.emmsale.notification.domain.UpdateNotificationRepository;
 import com.emmsale.notification.domain.UpdateNotificationType;

--- a/backend/emm-sale/src/main/java/com/emmsale/notification/application/UpdateNotificationCommandService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/notification/application/UpdateNotificationCommandService.java
@@ -54,7 +54,7 @@ public class UpdateNotificationCommandService {
       return;
     }
 
-    updateNotificationRepository.deleteAllByIdInBatch(deleteIdsOwnMember);
+    updateNotificationRepository.deleteBatchByIdsIn(deleteIdsOwnMember);
   }
 
   private boolean hasNoNotificationToDeleteBy(final List<Long> deleteIds) {

--- a/backend/emm-sale/src/main/java/com/emmsale/notification/domain/UpdateNotificationRepository.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/notification/domain/UpdateNotificationRepository.java
@@ -2,10 +2,17 @@ package com.emmsale.notification.domain;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UpdateNotificationRepository extends JpaRepository<UpdateNotification, Long> {
 
   List<UpdateNotification> findAllByReceiverId(final Long receiverId);
 
   List<UpdateNotification> findAllByIdIn(final List<Long> notificationIds);
+
+  @Modifying
+  @Query("delete from UpdateNotification un where un.id in :ids")
+  void deleteBatchByIdsIn(@Param("ids") final List<Long> notificationIds);
 }

--- a/backend/emm-sale/src/main/java/com/support/ConnectionProxyHandler.java
+++ b/backend/emm-sale/src/main/java/com/support/ConnectionProxyHandler.java
@@ -1,0 +1,45 @@
+package com.support;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.aop.framework.ProxyFactory;
+
+@RequiredArgsConstructor
+public class ConnectionProxyHandler implements MethodInterceptor {
+
+  private static final String JDBC_PREPARE_STATEMENT_METHOD_NAME = "prepareStatement";
+
+  private final Object connection;
+  private final LoggingForm loggingForm;
+
+  @Nullable
+  @Override
+  public Object invoke(@Nonnull final MethodInvocation invocation) throws Throwable {
+    final Object result = invocation.proceed();
+
+    if (hasConnection(result) && hasPreparedStatementInvoked(invocation)) {
+      final ProxyFactory proxyFactory = new ProxyFactory(result);
+      proxyFactory.addAdvice(new PreparedStatementProxyHandler(loggingForm));
+      return proxyFactory.getProxy();
+    }
+
+    return result;
+  }
+
+  private boolean hasPreparedStatementInvoked(final MethodInvocation invocation) {
+    return invocation.getMethod().getName().equals(JDBC_PREPARE_STATEMENT_METHOD_NAME);
+  }
+
+  private boolean hasConnection(final Object result) {
+    return result != null;
+  }
+
+  public Object getProxy() {
+    final ProxyFactory proxyFactory = new ProxyFactory(connection);
+    proxyFactory.addAdvice(this);
+    return proxyFactory.getProxy();
+  }
+}

--- a/backend/emm-sale/src/main/java/com/support/LoggingForm.java
+++ b/backend/emm-sale/src/main/java/com/support/LoggingForm.java
@@ -1,0 +1,30 @@
+package com.support;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class LoggingForm {
+
+  private String apiUrl;
+  private String apiMethod;
+  private Long queryCounts = 0L;
+  private Long queryTime = 0L;
+
+  public void queryCountUp() {
+    queryCounts++;
+  }
+
+  public void addQueryTime(final Long queryTime) {
+    this.queryTime += queryTime;
+  }
+
+  public void setApiUrl(final String apiUrl) {
+    this.apiUrl = apiUrl;
+  }
+
+  public void setApiMethod(final String apiMethod) {
+    this.apiMethod = apiMethod;
+  }
+}

--- a/backend/emm-sale/src/main/java/com/support/NPlus1DetectorAop.java
+++ b/backend/emm-sale/src/main/java/com/support/NPlus1DetectorAop.java
@@ -1,0 +1,54 @@
+package com.support;
+
+import javax.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Aspect
+@Slf4j
+public class NPlus1DetectorAop {
+
+  private final ThreadLocal<LoggingForm> currentLoggingForm;
+
+  public NPlus1DetectorAop() {
+    this.currentLoggingForm = new ThreadLocal<>();
+  }
+
+  @Around("execution( * javax.sql.DataSource.getConnection())")
+  public Object captureConnection(final ProceedingJoinPoint joinPoint) throws Throwable {
+    final Object connection = joinPoint.proceed();
+
+    return new ConnectionProxyHandler(connection, getCurrentLoggingForm()).getProxy();
+  }
+
+  private LoggingForm getCurrentLoggingForm() {
+    if (currentLoggingForm.get() == null) {
+      currentLoggingForm.set(new LoggingForm());
+    }
+
+    return currentLoggingForm.get();
+  }
+
+  @After("within(@org.springframework.web.bind.annotation.RestController *)")
+  public void loggingAfterApiFinish() {
+    final LoggingForm loggingForm = getCurrentLoggingForm();
+
+    ServletRequestAttributes attributes =
+        (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
+    if (attributes != null) {
+      HttpServletRequest request = attributes.getRequest();
+
+      loggingForm.setApiMethod(request.getMethod());
+      loggingForm.setApiUrl(request.getRequestURI());
+    }
+
+    log.info("{}", getCurrentLoggingForm());
+    currentLoggingForm.remove();
+  }
+}

--- a/backend/emm-sale/src/main/java/com/support/PreparedStatementProxyHandler.java
+++ b/backend/emm-sale/src/main/java/com/support/PreparedStatementProxyHandler.java
@@ -1,0 +1,38 @@
+package com.support;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+@RequiredArgsConstructor
+public class PreparedStatementProxyHandler implements MethodInterceptor {
+
+  private static final List<String> JDBC_QUERY_METHOD =
+      List.of("executeQuery", "execute", "executeUpdate");
+
+  private final LoggingForm loggingForm;
+
+  @Nullable
+  @Override
+  public Object invoke(@Nonnull final MethodInvocation invocation) throws Throwable {
+
+    final Method method = invocation.getMethod();
+
+    if (JDBC_QUERY_METHOD.contains(method.getName())) {
+      final long startTime = System.currentTimeMillis();
+      final Object result = invocation.proceed();
+      final long endTime = System.currentTimeMillis();
+
+      loggingForm.addQueryTime(endTime - startTime);
+      loggingForm.queryCountUp();
+
+      return result;
+    }
+
+    return invocation.proceed();
+  }
+}

--- a/backend/emm-sale/src/test/java/com/emmsale/comment/application/CommentCommandServiceEventIntegrationTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/comment/application/CommentCommandServiceEventIntegrationTest.java
@@ -1,0 +1,91 @@
+package com.emmsale.comment.application;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.emmsale.comment.application.dto.CommentAddRequest;
+import com.emmsale.comment.domain.Comment;
+import com.emmsale.comment.domain.CommentRepository;
+import com.emmsale.event.EventFixture;
+import com.emmsale.event.domain.Event;
+import com.emmsale.event.domain.repository.EventRepository;
+import com.emmsale.helper.ServiceIntegrationTestHelper;
+import com.emmsale.member.domain.Member;
+import com.emmsale.member.domain.MemberRepository;
+import com.emmsale.notification.application.FirebaseCloudMessageClient;
+import com.emmsale.notification.domain.UpdateNotification;
+import com.emmsale.notification.domain.UpdateNotificationRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+class CommentCommandServiceEventIntegrationTest extends ServiceIntegrationTestHelper {
+
+  @Autowired
+  private CommentCommandService commentCommandService;
+  @MockBean
+  private FirebaseCloudMessageClient firebaseCloudMessageClient;
+  @Autowired
+  private EventRepository eventRepository;
+  @Autowired
+  private CommentRepository commentRepository;
+  @Autowired
+  private MemberRepository memberRepository;
+  @Autowired
+  private UpdateNotificationRepository updateNotificationRepository;
+
+  @Test
+  @DisplayName("publish(Comment) : 댓글 이벤트가 성공적으로 발행되면 UpdateNotification이 성공적으로 저장될 수 있다.")
+  void test_publish_comment() throws Exception {
+    //given
+    final Event event = eventRepository.save(EventFixture.인프콘_2023());
+    final Member 댓글_작성자1 = memberRepository.findById(1L).get();
+    final Comment 부모_댓글 = commentRepository.save(Comment.createRoot(event, 댓글_작성자1, "내용1"));
+    final Member 댓글_작성자2 = memberRepository.save(new Member(13444L, "image", "username"));
+
+    doNothing().when(firebaseCloudMessageClient).sendMessageTo(any(UpdateNotification.class));
+
+    final CommentAddRequest 알림_트리거_댓글_요청 =
+        new CommentAddRequest("내용2", event.getId(), 부모_댓글.getId());
+
+    //when
+    commentCommandService.create(알림_트리거_댓글_요청, 댓글_작성자2);
+
+    //then
+    assertAll(
+        () -> verify(firebaseCloudMessageClient, times(1)).sendMessageTo(any(UpdateNotification.class)),
+        () -> assertEquals(1, updateNotificationRepository.findAll().size())
+    );
+  }
+
+  @Test
+  @DisplayName("publish(Comment) : 파이어베이스에 에러가 생겨도 UpdateNotification이 성공적으로 저장될 수 있다.")
+  void test_publish_comment_error_firebase() throws Exception {
+    //given
+    final Event event = eventRepository.save(EventFixture.인프콘_2023());
+    final Member 댓글_작성자1 = memberRepository.findById(1L).get();
+    final Comment 부모_댓글 = commentRepository.save(Comment.createRoot(event, 댓글_작성자1, "내용1"));
+    final Member 댓글_작성자2 = memberRepository.save(new Member(13444L, "image", "username"));
+
+    doThrow(new IllegalArgumentException("파이어베이스 에러"))
+        .when(firebaseCloudMessageClient).sendMessageTo(any(UpdateNotification.class));
+
+    final CommentAddRequest 알림_트리거_댓글_요청 =
+        new CommentAddRequest("내용2", event.getId(), 부모_댓글.getId());
+
+    //when
+    commentCommandService.create(알림_트리거_댓글_요청, 댓글_작성자2);
+
+    //then
+    assertAll(
+        () -> verify(firebaseCloudMessageClient, times(1)).sendMessageTo(any(UpdateNotification.class)),
+        () -> assertEquals(1, updateNotificationRepository.findAll().size())
+    );
+  }
+}

--- a/backend/emm-sale/src/test/java/com/emmsale/comment/application/CommentCommandServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/comment/application/CommentCommandServiceTest.java
@@ -7,15 +7,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 import com.emmsale.comment.application.dto.CommentAddRequest;
 import com.emmsale.comment.application.dto.CommentModifyRequest;
 import com.emmsale.comment.application.dto.CommentResponse;
 import com.emmsale.comment.domain.Comment;
 import com.emmsale.comment.domain.CommentRepository;
-import com.emmsale.comment.event.UpdateNotificationEvent;
 import com.emmsale.comment.exception.CommentException;
 import com.emmsale.comment.exception.CommentExceptionType;
 import com.emmsale.event.domain.Event;

--- a/backend/emm-sale/src/test/java/com/emmsale/comment/application/CommentCommandServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/comment/application/CommentCommandServiceTest.java
@@ -77,7 +77,7 @@ class CommentCommandServiceTest extends ServiceIntegrationTestHelper {
 
     final CommentAddRequest 부모_댓글_요청 = new CommentAddRequest(content, event.getId(), null);
 
-    doNothing().when(eventPublisher).publish(any(UpdateNotificationEvent.class));
+    doNothing().when(eventPublisher).publish(any(), any());
 
     //when
     final CommentResponse 부모_댓글_응답 = commentCommandService.create(부모_댓글_요청, 댓글_작성자);
@@ -91,22 +91,6 @@ class CommentCommandServiceTest extends ServiceIntegrationTestHelper {
   }
 
   @Test
-  @DisplayName("create() : 자신이 작성한 댓글이 Root 댓글이라면 알림이 가지 않는다.")
-  void test_create_root_notification() throws Exception {
-    //given
-    final String content = "내용";
-    final CommentAddRequest 부모_댓글_요청 = new CommentAddRequest(content, event.getId(), null);
-
-    doNothing().when(eventPublisher).publish(any(UpdateNotificationEvent.class));
-
-    //when
-    commentCommandService.create(부모_댓글_요청, 댓글_작성자);
-
-    //then
-    verify(eventPublisher, times(0)).publish(any(UpdateNotificationEvent.class));
-  }
-
-  @Test
   @DisplayName("create() : 댓글 부모 id가 있으면 그 자식 댓글(대댓글)을 생성할 수 있다.")
   void test_create_child() throws Exception {
     //given
@@ -117,7 +101,7 @@ class CommentCommandServiceTest extends ServiceIntegrationTestHelper {
     final CommentResponse 부모_댓글_응답 = commentCommandService.create(부모_댓글_요청, 댓글_작성자);
     final CommentAddRequest 자식_댓글_요청 = new CommentAddRequest(content, eventId, 1L);
 
-    doNothing().when(eventPublisher).publish(any(UpdateNotificationEvent.class));
+    doNothing().when(eventPublisher).publish(any(), any());
 
     //when
     final CommentResponse 자식_댓글_응답 = commentCommandService.create(자식_댓글_요청, 댓글_작성자);
@@ -128,134 +112,6 @@ class CommentCommandServiceTest extends ServiceIntegrationTestHelper {
         () -> assertNotNull(자식_댓글_응답.getCommentId()),
         () -> assertEquals(부모_댓글_응답.getCommentId(), 자식_댓글_응답.getParentId())
     );
-  }
-
-  @Test
-  @DisplayName("create() : 대댓글을 생성할 경우 부모, 자식 댓글에서 나의 댓글만 존재한다면 알림이 가지 않는다.")
-  void test_create_child_not_notification() throws Exception {
-    //given
-    final String content = "내용";
-    final Long eventId = event.getId();
-
-    final CommentAddRequest 부모_댓글_요청 = new CommentAddRequest(content, eventId, null);
-    commentCommandService.create(부모_댓글_요청, 댓글_작성자);
-    final CommentAddRequest 자식_댓글_요청 = new CommentAddRequest(content, eventId, 1L);
-
-    doNothing().when(eventPublisher).publish(any(UpdateNotificationEvent.class));
-
-    //when
-    commentCommandService.create(자식_댓글_요청, 댓글_작성자);
-
-    //then
-    verify(eventPublisher, times(0)).publish(any(UpdateNotificationEvent.class));
-  }
-
-  /**
-   * 1
-   * ㄴ2  (1에게 알림)
-   * ㄴ3  (1,2에게 알림)
-   * <p>
-   * 새로운 대댓글
-   * ㄴ2  (1,3에게 알림)
-   */
-  @Test
-  @DisplayName("create() : 자신이 작성한 댓글, 대댓글들 중에서 다른 사람이 댓글을 작성할 경우 알림이 온다.")
-  void test_create_child_notification() throws Exception {
-    //given
-    final String content = "내용";
-    final Long eventId = event.getId();
-    final Member 댓글_작성자2 = memberRepository.findById(2L).get();
-    final Member savedMember = memberRepository.save(new Member(200L, "imageUrl", "아마란스"));
-    final Member 댓글_작성자3 = memberRepository.findById(savedMember.getId()).get();
-
-    doNothing().when(eventPublisher).publish(any(UpdateNotificationEvent.class));
-
-    final CommentAddRequest 부모_댓글_요청 = new CommentAddRequest(content, eventId, null);
-    commentCommandService.create(부모_댓글_요청, 댓글_작성자);
-
-    // 댓글_작성자에게 알림 1번
-    final CommentAddRequest 자식_댓글_요청1 = new CommentAddRequest(content, eventId, 1L);
-    commentCommandService.create(자식_댓글_요청1, 댓글_작성자2);
-
-    // 댓글_작성자, 댓글_작성자2에게 알림 각각 1번
-    final CommentAddRequest 자식_댓글_요청2 = new CommentAddRequest(content, eventId, 1L);
-    commentCommandService.create(자식_댓글_요청2, 댓글_작성자3);
-
-    final CommentAddRequest 알림이_가는_자식_댓글_요청 = new CommentAddRequest(content, eventId, 1L);
-
-    //when  댓글_작성자, 댓글_작성자3에게 알림 각각 1번
-    commentCommandService.create(알림이_가는_자식_댓글_요청, 댓글_작성자2);
-
-    //then
-    verify(eventPublisher, times(5)).publish(any(UpdateNotificationEvent.class));
-  }
-
-  @Test
-  @DisplayName("create() : 삭제된 댓글에 대해서는 알림이 가지 않는다.")
-  void test_create_not_notification_deletedComment() throws Exception {
-    //given
-    final String content = "내용";
-    final Long eventId = event.getId();
-    final Member 댓글_작성자2 = memberRepository.findById(2L).get();
-    final Member savedMember = memberRepository.save(new Member(200L, "imageUrl", "아마란스"));
-    final Member 댓글_작성자3 = memberRepository.findById(savedMember.getId()).get();
-
-    doNothing().when(eventPublisher).publish(any(UpdateNotificationEvent.class));
-
-    final CommentAddRequest 부모_댓글_요청 = new CommentAddRequest(content, eventId, null);
-    commentCommandService.create(부모_댓글_요청, 댓글_작성자);
-
-    // 댓글_작성자에게 알림 1번
-    final CommentAddRequest 자식_댓글_요청1 = new CommentAddRequest(content, eventId, 1L);
-    commentCommandService.create(자식_댓글_요청1, 댓글_작성자2);
-
-    // 댓글_작성자, 댓글_작성자2에게 알림 각각 1번
-    final CommentAddRequest 자식_댓글_요청2 = new CommentAddRequest(content, eventId, 1L);
-    final CommentResponse response = commentCommandService.create(자식_댓글_요청2, 댓글_작성자3);
-    commentCommandService.delete(response.getCommentId(), 댓글_작성자3);
-
-    final CommentAddRequest 알림이_가는_자식_댓글_요청 = new CommentAddRequest(content, eventId, 1L);
-
-    //when  댓글_작성자에게 알림 1번, 댓글_작성자3은 삭제된 댓글이므로 알림이 가지 않음
-    commentCommandService.create(알림이_가는_자식_댓글_요청, 댓글_작성자2);
-
-    //then
-    verify(eventPublisher, times(4)).publish(any(UpdateNotificationEvent.class));
-  }
-
-  @Test
-  @DisplayName("create() : 삭제된 댓글에 대해서는 알림이 가지 않는다.")
-  void test_create_not_notification_deletedComment2() throws Exception {
-    //given
-    final String content = "내용";
-    final Long eventId = event.getId();
-    final Member 댓글_작성자2 = memberRepository.findById(2L).get();
-    final Member savedMember = memberRepository.save(new Member(200L, "imageUrl", "아마란스"));
-    final Member 댓글_작성자3 = memberRepository.findById(savedMember.getId()).get();
-
-    doNothing().when(eventPublisher).publish(any(UpdateNotificationEvent.class));
-
-    final CommentAddRequest 부모_댓글_요청 = new CommentAddRequest(content, eventId, null);
-    final CommentResponse response = commentCommandService.create(부모_댓글_요청, 댓글_작성자);
-
-    // 댓글_작성자에게 알림 1번
-    final CommentAddRequest 자식_댓글_요청1 = new CommentAddRequest(content, eventId, 1L);
-    commentCommandService.create(자식_댓글_요청1, 댓글_작성자2);
-
-    // 댓글_작성자의 댓글 삭제
-    commentCommandService.delete(response.getCommentId(), 댓글_작성자);
-
-    // 댓글_작성자의 댓글은 삭제 -> 알림 X, 댓글_작성자2에게 알림 1번
-    final CommentAddRequest 자식_댓글_요청2 = new CommentAddRequest(content, eventId, 1L);
-    commentCommandService.create(자식_댓글_요청2, 댓글_작성자3);
-
-    final CommentAddRequest 알림이_가는_자식_댓글_요청 = new CommentAddRequest(content, eventId, 1L);
-
-    //when  댓글_작성자 삭제 -> 알림 X, 댓글_작성자3 알림 1번
-    commentCommandService.create(알림이_가는_자식_댓글_요청, 댓글_작성자2);
-
-    //then
-    verify(eventPublisher, times(3)).publish(any(UpdateNotificationEvent.class));
   }
 
   @Test

--- a/backend/emm-sale/src/test/java/com/emmsale/event_publisher/EventPublisherTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event_publisher/EventPublisherTest.java
@@ -209,6 +209,24 @@ class EventPublisherTest extends ServiceIntegrationTestHelper {
   }
 
   @Test
+  @DisplayName("publish(Comment) : 자신이 작성한 댓글이 Root 댓글이라면 알림이 가지 않는다.")
+  void test_publish_root_comment_no_notification() throws Exception {
+    //given
+    final Member 댓글_작성자1 = memberRepository.findById(1L).get();
+    eventRepository.save(event);
+    final Comment 알림_트리거_댓글 = commentRepository.save(
+        Comment.createRoot(event, 댓글_작성자1, "내용1")
+    );
+
+    //when
+    eventPublisher.publish(알림_트리거_댓글, 댓글_작성자1);
+
+    //then
+    verify(applicationEventPublisher, times(0))
+        .publishEvent(any(UpdateNotificationEvent.class));
+  }
+
+  @Test
   @DisplayName("publish(Comment) : 삭제된 댓글에 대해서는 알림이 가지 않는다.")
   void test_publish_comment_not_notification_deletedComment() throws Exception {
     //given

--- a/backend/emm-sale/src/test/java/com/emmsale/event_publisher/EventPublisherTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event_publisher/EventPublisherTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.verify;
 
 import com.emmsale.comment.domain.Comment;
 import com.emmsale.comment.domain.CommentRepository;
-import com.emmsale.comment.event.UpdateNotificationEvent;
 import com.emmsale.event.EventFixture;
 import com.emmsale.event.domain.Event;
 import com.emmsale.event.domain.repository.EventRepository;

--- a/backend/emm-sale/src/test/java/com/emmsale/notification/application/NotificationEventListenerTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/notification/application/NotificationEventListenerTest.java
@@ -7,8 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.emmsale.comment.domain.Comment;
-import com.emmsale.comment.event.UpdateNotificationEvent;
+import com.emmsale.event_publisher.UpdateNotificationEvent;
 import com.emmsale.helper.ServiceIntegrationTestHelper;
 import com.emmsale.notification.domain.UpdateNotification;
 import com.emmsale.notification.domain.UpdateNotificationRepository;

--- a/backend/emm-sale/src/test/java/com/emmsale/notification/application/UpdateNotificationCommandServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/notification/application/UpdateNotificationCommandServiceTest.java
@@ -19,6 +19,7 @@ import com.emmsale.notification.domain.UpdateNotification;
 import com.emmsale.notification.domain.UpdateNotificationRepository;
 import com.emmsale.notification.domain.UpdateNotificationType;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -38,6 +39,7 @@ class UpdateNotificationCommandServiceTest extends ServiceIntegrationTestHelper 
 
   private UpdateNotification 이벤트_알림;
   private Member member;
+  private UpdateNotification notification1, notification2, notification3;
 
   @BeforeEach
   void setUp() {
@@ -52,6 +54,23 @@ class UpdateNotificationCommandServiceTest extends ServiceIntegrationTestHelper 
             LocalDateTime.now()
         )
     );
+
+    final Long receiverId = member.getId();
+
+    notification1 = new UpdateNotification(
+        receiverId, 2L,
+        UpdateNotificationType.COMMENT, LocalDateTime.now()
+    );
+    notification2 = new UpdateNotification(
+        receiverId, 3L,
+        UpdateNotificationType.EVENT, LocalDateTime.now()
+    );
+    notification3 = new UpdateNotification(
+        2L, 4L,
+        UpdateNotificationType.COMMENT, LocalDateTime.now()
+    );
+
+    updateNotificationRepository.saveAll(List.of(notification1, notification2, notification3));
   }
 
   @Test
@@ -87,30 +106,17 @@ class UpdateNotificationCommandServiceTest extends ServiceIntegrationTestHelper 
   @DisplayName("deleteBatch() : 댓글 & 행사 알림을 삭제할 ID로 본인의 알림들만을 삭제할 수 있다.")
   void test_deleteBatch() throws Exception {
     //given
-    final Long receiverId = member.getId();
-
-    final UpdateNotification notification1 = new UpdateNotification(
-        receiverId, 2L,
-        UpdateNotificationType.COMMENT, LocalDateTime.now()
-    );
-    final UpdateNotification notification2 = new UpdateNotification(
-        receiverId, 3L,
-        UpdateNotificationType.EVENT, LocalDateTime.now()
-    );
-    final UpdateNotification notification3 = new UpdateNotification(
-        2L, 4L,
-        UpdateNotificationType.COMMENT, LocalDateTime.now()
-    );
-    updateNotificationRepository.saveAll(List.of(notification1, notification2, notification3));
+    final List<Long> nonExistedNotificationIds = List.of(4L, 5L, 6L);
+    final List<Long> deletedIds = new ArrayList<>();
+    deletedIds.addAll(nonExistedNotificationIds);
+    deletedIds.addAll(List.of(
+        notification1.getId(),
+        notification2.getId(),
+        notification3.getId()
+    ));
 
     final UpdateNotificationDeleteRequest request =
-        new UpdateNotificationDeleteRequest(
-            List.of(
-                notification1.getId(),
-                notification2.getId(),
-                notification3.getId()
-            )
-        );
+        new UpdateNotificationDeleteRequest(deletedIds);
 
     final List<UpdateNotification> expected = List.of(notification3);
 

--- a/backend/emm-sale/src/test/java/com/emmsale/notification/domain/UpdateNotificationRepositoryTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/notification/domain/UpdateNotificationRepositoryTest.java
@@ -3,6 +3,8 @@ package com.emmsale.notification.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -69,6 +71,7 @@ class UpdateNotificationRepositoryTest {
   void test_findAllByIdsIn() throws Exception {
     //given
     final List<UpdateNotification> expected = List.of(notification1, notification2);
+
     final List<Long> notificationIds = List.of(notification1.getId(), notification2.getId());
 
     //when
@@ -76,6 +79,33 @@ class UpdateNotificationRepositoryTest {
         updateNotificationRepository.findAllByIdIn(notificationIds);
 
     //then
+    assertThat(actual)
+        .usingRecursiveComparison()
+        .ignoringCollectionOrder()
+        .ignoringFields("createdAt")
+        .isEqualTo(expected);
+  }
+
+  @Test
+  @DisplayName("deleteBatchByIdsIn() : IN 쿼리를 통해 알림들을 배치 삭제할 수 있다.")
+  void test_deleteBatchByIdsIn() throws Exception {
+    //given
+    //존재하지 않는 알림 ID
+    final List<Long> nonExistedNotificationIds = List.of(3L, 4L, 5L);
+    final List<Long> existedNotificationIds = List.of(notification1.getId(), notification2.getId());
+    final List<Long> deleteIds = new ArrayList<>();
+    deleteIds.addAll(nonExistedNotificationIds);
+    deleteIds.addAll(existedNotificationIds);
+
+    final List<Long> actual = Collections.emptyList();
+
+    //when
+    updateNotificationRepository.deleteBatchByIdsIn(deleteIds);
+
+    //then
+    final List<UpdateNotification> expected =
+        updateNotificationRepository.findAllByIdIn(deleteIds);
+
     assertThat(actual)
         .usingRecursiveComparison()
         .ignoringCollectionOrder()


### PR DESCRIPTION
## #️⃣연관된 이슈
- #492 

## 📝작업 내용

댓글 & 행사 알림 다건 삭제 시 @Modifying, @Query 를 사용하여 배치 삭제로 구현


## 예상 소요 시간 및 실제 소요 시간
5시간 / 5시간


## 💬리뷰 요구사항(선택)
이전 PR로부터 브랜치를 파서
23b7cb7935c26cbc3a1113270726c2f0811ae698 커밋만 보시면 됩니다

![image](https://github.com/woowacourse-teams/2023-emmsale/assets/62413589/dbe472a1-eabd-40f3-8c62-b9cedeea1d63)
