### PR TITLE
Feature/#496 event detail view model 테스트 구현

### DIFF
--- a/android/2023-emmsale/app/build.gradle.kts
+++ b/android/2023-emmsale/app/build.gradle.kts
@@ -59,7 +59,6 @@ android {
         enable = true
     }
     tasks.withType(Test::class) {
-        useJUnitPlatform()
         testLogging {
             events.addAll(
                 arrayOf(
@@ -70,6 +69,9 @@ android {
             )
         }
     }
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 fun getApiKey(propertyKey: String): String {
@@ -77,39 +79,67 @@ fun getApiKey(propertyKey: String): String {
 }
 
 dependencies {
+
+    // Android
     implementation("androidx.core:core-ktx:1.10.1")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.9.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.legacy:legacy-support-v4:1.0.0")
-    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.6.1")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1")
     implementation("androidx.browser:browser:1.5.0")
     implementation("androidx.work:work-runtime-ktx:2.8.1")
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+
+    // ViewModel
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.6.1")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1")
     implementation("androidx.fragment:fragment-ktx:1.6.1")
+
+    // Retrofit
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
-    implementation("com.squareup.okhttp3:okhttp:4.11.0")
-    implementation("com.squareup.okhttp3:mockwebserver:4.11.0")
+
+    // Kotlinx-Serialization
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
     implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0")
+
+    // OkHttp3
     implementation("com.squareup.okhttp3:logging-interceptor:4.8.0")
+    implementation("com.squareup.okhttp3:okhttp:4.11.0")
+    implementation("com.squareup.okhttp3:mockwebserver:4.11.0")
+
+    // Glide
     implementation("com.github.bumptech.glide:glide:4.15.1")
+
+    // SwipeRefresh
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
 
+    // Firebase
     implementation(platform("com.google.firebase:firebase-bom:32.2.0"))
     implementation("com.google.firebase:firebase-analytics-ktx")
     implementation("com.google.firebase:firebase-messaging-ktx")
     implementation("com.google.firebase:firebase-crashlytics-ktx")
 
     testImplementation("org.junit.jupiter", "junit-jupiter", "5.8.2")
-    testImplementation("org.assertj", "assertj-core", "3.22.0")
     testImplementation("io.mockk:mockk-android:1.13.5")
     testImplementation("io.mockk:mockk-agent:1.13.5")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
 
+    // junit4
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("androidx.test.ext:junit:1.1.5")
+    testImplementation("androidx.test:runner:1.5.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+
+    // assertJ
+    testImplementation("org.assertj:assertj-core:3.22.0")
+
+    // android-test
+    testImplementation("androidx.arch.core:core-testing:2.2.0")
+
+    // recyclerView
     implementation("androidx.recyclerview:recyclerview:1.3.1")
+
+    // SplashScreen
     implementation("androidx.core:core-splashscreen:1.0.0-beta01")
 
     // imageview

--- a/android/2023-emmsale/app/src/test/java/com/emmsale/presentation/ui/eventdetail/EventDetailViewModelTest.kt
+++ b/android/2023-emmsale/app/src/test/java/com/emmsale/presentation/ui/eventdetail/EventDetailViewModelTest.kt
@@ -1,0 +1,102 @@
+package com.emmsale.presentation.ui.eventdetail
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.emmsale.data.common.ApiError
+import com.emmsale.data.common.ApiSuccess
+import com.emmsale.data.eventdetail.EventDetail
+import com.emmsale.data.eventdetail.EventDetailRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import okhttp3.Headers
+import org.assertj.core.api.SoftAssertions
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.time.LocalDateTime
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EventDetailViewModelTest {
+
+    private lateinit var vm: EventDetailViewModel
+    private lateinit var eventDetailRepository: EventDetailRepository
+
+    private val testEventDetail = EventDetail(
+        id = 1L,
+        name = "Florence Joseph",
+        informationUrl = "https://search.yahoo.com/search?p=mediocrem",
+        startDate = LocalDateTime.now(),
+        endDate = LocalDateTime.now(),
+        applyStartDate = LocalDateTime.now(),
+        applyEndDate = LocalDateTime.now(),
+        location = "hinc",
+        status = "tamquam",
+        applyStatus = "graecis",
+        tags = listOf(),
+        posterImageUrl = null,
+        remainingDays = 9431,
+        applyRemainingDays = 2123,
+        type = "minim",
+    )
+
+    @get:Rule
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        eventDetailRepository = mockk(relaxed = true)
+        vm = EventDetailViewModel(1L, eventDetailRepository)
+    }
+
+    @After
+    fun finish() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `정상적으로 상세정보를 받아온다면, id가 1인 상세정보를 요청했을 때, eventDetail 은 Error와 Loading 상태가 false 이고 id가 1이다 `() {
+        // given
+        coEvery {
+            eventDetailRepository.getEventDetail(1L)
+        } answers {
+            ApiSuccess(testEventDetail, Headers.headersOf("Auth", "hi"))
+        }
+
+        // when
+        vm.refresh()
+
+        // then
+        val softly = SoftAssertions().apply {
+            assertThat(vm.eventDetail.value.isError).isEqualTo(false)
+            assertThat(vm.eventDetail.value.isLoading).isEqualTo(false)
+            assertThat(vm.eventDetail.value.id).isEqualTo(1L)
+        }
+        softly.assertAll()
+    }
+
+    @Test
+    fun `정상적으로 상세정보를 받아올 수 없다면, id가 1인 상세정보를 요청했을 때, eventDetail은 Error 상태가 된다 `() {
+        // given
+        coEvery {
+            eventDetailRepository.getEventDetail(1L)
+        } answers {
+            ApiError(code = 4548, message = null)
+        }
+
+        // when
+        vm.refresh()
+
+        // then
+        val softly = SoftAssertions().apply {
+            assertThat(vm.eventDetail.value.isError).isEqualTo(true)
+            assertThat(vm.eventDetail.value.isLoading).isEqualTo(false)
+        }
+        softly.assertAll()
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#496 

## 📝작업 내용
EventDetailViewModel의 테스트를 구현하였어요

## 예상 소요 시간 및 실제 소요 시간
> 이슈의 예상 소요 시간과 실제 소요된 시간을 분 or 시간 or 일 단위로 작성해주세요.
1시간/ 6시간

## 💬리뷰 요구사항
테스트 오랜만에 짜봐서 피드백 부탁드려요

## 테스트 공부 공유사항
오늘은 ViewModel Test에 대해 공부하였다. 

### LiveData Test Setting

먼저, ViewModel 에서 사용하는 LiveData 를 테스트 하려면 

```kotlin
@get:Rule
val instantExecutorRule = InstantTaskExecutorRule()
```

이 룰을 추가해야만 한다.

### Coroutine Test Setting

또한 코루틴을 테스트 하려면,

```kotlin
@OptIn(ExperimentalCoroutinesApi::class)
class EventDetailViewModelTest {
```

이 코드와 같이 @OptIn(ExperimentalCoroutinesApi::class) 어노테이션을 클래스위에 추가해주고, 

```kotlin
@Before
fun setUp() {
    Dispatchers.setMain(UnconfinedTestDispatcher())
```

SetUp 단계에서 DisPatcher 를 테스트용 디스패처(UnconfinedTestDispatcher)를 쓰겠다고 정의를 해주어야 한다.

```kotlin
@After
fun finish() {
    Dispatchers.resetMain()
}
```

그리고 After 단계에서 다시 메인 으로 돌려주어야 나머지 테스트도 잘 돌아가게 할 수 있다.

### Suspend Function Mock Test

또한 정지함수를 테스트 할 때 Mock 사용법은 약간 다른데,

```
coEvery{
eventDetailRepository.getEventDetail(1L)
}answers{
ApiSuccess(testEventDetail, Headers.headersOf("Auth", "hi"))
}
```

이 코드와 같이 coEvery 처럼 Every 앞에 co를 붙여 정지함수라는 것을 표시해주어야 한다.

### Soft Assertion

많은 Assertion 을 하고싶을때, 그냥 assertThat을 나열하게 되면, 중간에 실패하면 뒤에 Assertion 은 확인하지 않는다. 중간에 실패해도 계속 실행하고 싶을 때, SoftAssertion을 사용하면 좋다.

### 삽질 기록

먼저, 

```
testOptions{
unitTests.isReturnDefaultValues = true
}
```

이 코드를 app 수준 Gradle에 추가하지 않으면 , 

> Method getMainLooper in android.os.Looper not mocked.
> 

이러한 에러 메세지를 얻게 될것이다.  

또한 JUnit5로 ViewModel 을 테스트하려고 한다면, 

> android.os.getLooper is null
> 

이라는 에러 메세지를 얻게 될것이다. 그 이유는 위에서 사용한 Test Rule 들은 모두 JUnit4를 기반으로 만들어졌기 때문에, JUnit5로 테스트하기 위해서는 많은 과정이 필요하다. 

참고 글: [[https://modelmaker.tistory.com/entry/안드로이드-테스트-코드-Truth-with-JUnit5](https://modelmaker.tistory.com/entry/%EC%95%88%EB%93%9C%EB%A1%9C%EC%9D%B4%EB%93%9C-%ED%85%8C%EC%8A%A4%ED%8A%B8-%EC%BD%94%EB%93%9C-Truth-with-JUnit5)](https://modelmaker.tistory.com/entry/%EC%95%88%EB%93%9C%EB%A1%9C%EC%9D%B4%EB%93%9C-%ED%85%8C%EC%8A%A4%ED%8A%B8-%EC%BD%94%EB%93%9C-Truth-with-JUnit5)

따라서 나는 JUnit4로 테스트를 실행했는데, 계속 

> Tests were not received
> 

메세지가 뜨며, 테스트를 인식하지 못했다… 그 뒤로 엄청나게 오랬동안 삽질을 하다가 원인을 찾아냈다.

![image](https://github.com/woowacourse-teams/2023-emmsale/assets/76036731/feae4be2-6a5d-4d1f-a01a-f35302a41d33)


바로 useJUnitPlatForm 이라는 함수 때문이었다. 저 함수는 모든 안드로이드 테스트를 JUnit5로 실행하겠다는 함수였고, 그래서 JUnit4 테스트를 인식하지 못했던 것이다. 따라서, 저 함수를 지워주니 바로 해결되었다.