### PR TITLE
Feature/#507 쪽지함에서 쪽지방 목록 조회

### DIFF
--- a/backend/emm-sale/src/documentTest/asciidoc/index.adoc
+++ b/backend/emm-sale/src/documentTest/asciidoc/index.adoc
@@ -609,3 +609,19 @@ include::{snippets}/delete-scrap/http-request.adoc[]
 
 .HTTP response
 include::{snippets}/delete-scrap/http-response.adoc[]
+
+== Message (쪽지)
+
+=== `GET` : 쪽지함 목록 조회
+
+.HTTP request
+include::{snippets}/get-rooms/http-request.adoc[]
+
+.HTTP request 설명
+include::{snippets}/get-rooms/request-parameters.adoc[]
+
+.HTTP response
+include::{snippets}/get-rooms/http-response.adoc[]
+
+.HTTP response 설명
+include::{snippets}/get-rooms/response-fields.adoc[]

--- a/backend/emm-sale/src/documentTest/java/com/emmsale/MockMvcTestHelper.java
+++ b/backend/emm-sale/src/documentTest/java/com/emmsale/MockMvcTestHelper.java
@@ -16,6 +16,7 @@ import com.emmsale.member.application.InterestTagService;
 import com.emmsale.member.application.MemberActivityService;
 import com.emmsale.member.application.MemberQueryService;
 import com.emmsale.member.application.MemberUpdateService;
+import com.emmsale.message_room.application.RoomQueryService;
 import com.emmsale.notification.application.FcmTokenRegisterService;
 import com.emmsale.notification.application.RequestNotificationCommandService;
 import com.emmsale.notification.application.RequestNotificationQueryService;
@@ -96,6 +97,8 @@ abstract class MockMvcTestHelper {
   protected RecruitmentPostQueryService postQueryService;
   @MockBean
   protected RecruitmentPostCommandService postCommandService;
+  @MockBean
+  protected RoomQueryService roomQueryService;
 
   @BeforeEach
   void setUp(final WebApplicationContext applicationContext,

--- a/backend/emm-sale/src/documentTest/java/com/emmsale/RoomApiTest.java
+++ b/backend/emm-sale/src/documentTest/java/com/emmsale/RoomApiTest.java
@@ -39,15 +39,16 @@ class RoomApiTest extends MockMvcTestHelper {
 
     final ResponseFieldsSnippet responseFields = responseFields(
         fieldWithPath("[].roomId").description("Room Id(String 타입의 UUID입니다)"),
-        fieldWithPath("[].senderName").description("최근 메시지를 보낸 사람 이름"),
-        fieldWithPath("[].recentlyMessage").description("최근 메시지"),
+        fieldWithPath("[].interlocutorId").description("쪽지를 주고받는 상대방 ID"),
+        fieldWithPath("[].interlocutorName").description("쪽지를 주고받는 상대방의 이름"),
+        fieldWithPath("[].recentlyMessage").description("최근 메시지 내용"),
         fieldWithPath("[].recentlyMessageTime").description("최근 메시지 시간")
     );
 
     final List<RoomResponse> roomResponses = List.of(
-        new RoomResponse(UUID.randomUUID().toString(), "receiver1", "최근 메시지1", LocalDateTime.now()),
-        new RoomResponse(UUID.randomUUID().toString(), "receiver2", "최근 메시지2", LocalDateTime.now().minusDays(2)),
-        new RoomResponse(UUID.randomUUID().toString(), "receiver3", "최근 메시지3", LocalDateTime.now().minusDays(3))
+        new RoomResponse(UUID.randomUUID().toString(), 1L,"receiver1", "최근 메시지1", LocalDateTime.now()),
+        new RoomResponse(UUID.randomUUID().toString(), 1L,"receiver2", "최근 메시지2", LocalDateTime.now().minusDays(2)),
+        new RoomResponse(UUID.randomUUID().toString(), 1L,"receiver3", "최근 메시지3", LocalDateTime.now().minusDays(3))
     );
 
     when(roomQueryService.findAll(any(), anyLong()))

--- a/backend/emm-sale/src/documentTest/java/com/emmsale/RoomApiTest.java
+++ b/backend/emm-sale/src/documentTest/java/com/emmsale/RoomApiTest.java
@@ -1,0 +1,64 @@
+package com.emmsale;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.emmsale.message_room.api.RoomApi;
+import com.emmsale.message_room.application.dto.RoomResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+import org.springframework.restdocs.request.RequestParametersSnippet;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@WebMvcTest(RoomApi.class)
+class RoomApiTest extends MockMvcTestHelper {
+
+  @Test
+  @DisplayName("findAllRoom() : 사용자의 쪽지함을 성공적으로 조회하면 200 OK를 반환할 수 있다.")
+  void test_findAllRoom() throws Exception {
+    //given
+    final String accessToken = "Bearer AccessToken";
+
+    final RequestParametersSnippet requestParam = requestParameters(
+        parameterWithName("member-id").description("조회할 사용자의 ID")
+    );
+
+    final ResponseFieldsSnippet responseFields = responseFields(
+        fieldWithPath("[].roomId").description("Room Id(String 타입의 UUID입니다)"),
+        fieldWithPath("[].senderName").description("최근 메시지를 보낸 사람 이름"),
+        fieldWithPath("[].recentlyMessage").description("최근 메시지"),
+        fieldWithPath("[].recentlyMessageTime").description("최근 메시지 시간")
+    );
+
+    final List<RoomResponse> roomResponses = List.of(
+        new RoomResponse(UUID.randomUUID().toString(), "receiver1", "최근 메시지1", LocalDateTime.now()),
+        new RoomResponse(UUID.randomUUID().toString(), "receiver2", "최근 메시지2", LocalDateTime.now().minusDays(2)),
+        new RoomResponse(UUID.randomUUID().toString(), "receiver3", "최근 메시지3", LocalDateTime.now().minusDays(3))
+    );
+
+    when(roomQueryService.findAll(any(), anyLong()))
+        .thenReturn(roomResponses);
+
+    //when & then
+    mockMvc.perform(MockMvcRequestBuilders.get("/rooms")
+            .queryParam("member-id", "1")
+            .header(HttpHeaders.AUTHORIZATION, accessToken))
+        .andExpect(status().isOk())
+        .andDo(print())
+        .andDo(document("get-rooms", requestParam, responseFields));
+  }
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/message/domain/Message.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message/domain/Message.java
@@ -1,0 +1,47 @@
+package com.emmsale.message.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Message {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String content;
+
+  @Column(nullable = false)
+  private Long senderId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Room room;
+
+  private LocalDateTime createdAt;
+
+  public Message(
+      final String content,
+      final Long senderId,
+      final Room room
+  ) {
+    this.content = content;
+    this.senderId = senderId;
+    this.room = room;
+    this.createdAt = LocalDateTime.now();
+  }
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/message/domain/Room.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message/domain/Room.java
@@ -1,0 +1,45 @@
+package com.emmsale.message.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Room {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, name = "member1_id")
+  private Long member1Id;
+
+  @Column(nullable = false, name = "member1_last_exited_time")
+  private LocalDateTime member1LastExitedTime;
+
+  @Column(nullable = false, name = "member2_id")
+  private Long member2Id;
+
+  @Column(nullable = false, name = "member2_last_exited_time")
+  private LocalDateTime member2LastExitedTime;
+
+  public Room(
+      final Long member1Id,
+      final LocalDateTime member1LastExitedTime,
+      final Long member2Id,
+      final LocalDateTime member2LastExitedTime
+  ) {
+    this.member1Id = member1Id;
+    this.member1LastExitedTime = member1LastExitedTime;
+    this.member2Id = member2Id;
+    this.member2LastExitedTime = member2LastExitedTime;
+  }
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/api/RoomApi.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/api/RoomApi.java
@@ -1,10 +1,25 @@
 package com.emmsale.message_room.api;
 
+import com.emmsale.member.domain.Member;
+import com.emmsale.message_room.application.RoomQueryService;
+import com.emmsale.message_room.application.dto.RoomResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 public class RoomApi {
 
+  private final RoomQueryService roomQueryService;
+
+  @GetMapping("/rooms")
+  public List<RoomResponse> findAllRoom(
+      final Member loginMember,
+      @RequestParam("member-id") final Long memberId
+  ) {
+    return roomQueryService.findAll(loginMember, memberId);
+  }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/api/RoomApi.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/api/RoomApi.java
@@ -1,0 +1,10 @@
+package com.emmsale.message_room.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class RoomApi {
+
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/application/RoomCommandService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/application/RoomCommandService.java
@@ -1,0 +1,10 @@
+package com.emmsale.message_room.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class RoomCommandService {
+
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/application/RoomQueryService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/application/RoomQueryService.java
@@ -1,14 +1,20 @@
 package com.emmsale.message_room.application;
 
+import static com.emmsale.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
 import static com.emmsale.member.exception.MemberExceptionType.NOT_MATCHING_TOKEN_AND_LOGIN_MEMBER;
 
 import com.emmsale.member.domain.Member;
+import com.emmsale.member.domain.MemberRepository;
 import com.emmsale.member.exception.MemberException;
 import com.emmsale.message_room.application.dto.RoomResponse;
+import com.emmsale.message_room.domain.Room;
+import com.emmsale.message_room.domain.RoomRepository;
 import com.emmsale.message_room.infrastructure.persistence.MessageDao;
-import java.util.Comparator;
+import com.emmsale.message_room.infrastructure.persistence.dto.MessageOverview;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,21 +24,60 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class RoomQueryService {
 
+  private final RoomRepository roomRepository;
   private final MessageDao messageDao;
+  private final MemberRepository memberRepository;
 
   public List<RoomResponse> findAll(final Member loginMember, final Long memberId) {
     validateSameMember(loginMember, memberId);
 
-    return messageDao.findRecentlyMessages(memberId)
-        .stream()
-        .map(RoomResponse::from)
-        .sorted(Comparator.comparing(RoomResponse::getRecentlyMessageTime).reversed())
+    final Long loginMemberId = loginMember.getId();
+
+    final List<MessageOverview> messageOverviews = messageDao.findRecentlyMessages(loginMemberId);
+
+    final Map<String, Long> interlocutorIdPerRoomExceptMe = groupingPartnerIdByRoom(
+        messageOverviews,
+        loginMemberId
+    );
+
+    return messageOverviews.stream()
+        .map(messageOverview ->
+            RoomResponse.from(
+                messageOverview,
+                findInterlocutor(interlocutorIdPerRoomExceptMe.get(messageOverview.getRoomUUID()))
+            ))
         .collect(Collectors.toList());
+  }
+
+  private Map<String, Long> groupingPartnerIdByRoom(
+      final List<MessageOverview> messageOverviews,
+      final Long loginMemberId
+  ) {
+    return messageOverviews.stream()
+        .flatMap(messageOverview -> findInterlocutorInRoom(messageOverview, loginMemberId))
+        .collect(Collectors.toMap(
+            room -> room.getRoomId().getUuid(),
+            room -> room.getRoomId().getMemberId())
+        );
+  }
+
+  private Stream<Room> findInterlocutorInRoom(
+      final MessageOverview messageOverview,
+      final Long loginMemberId
+  ) {
+    return roomRepository.findByUUID(messageOverview.getRoomUUID())
+        .stream()
+        .filter(room -> room.isInterlocutorWith(loginMemberId));
   }
 
   private void validateSameMember(final Member loginMember, final Long memberId) {
     if (loginMember.isNotMe(memberId)) {
       throw new MemberException(NOT_MATCHING_TOKEN_AND_LOGIN_MEMBER);
     }
+  }
+
+  private Member findInterlocutor(final Long interlocutorId) {
+    return memberRepository.findById(interlocutorId)
+        .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/application/RoomQueryService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/application/RoomQueryService.java
@@ -1,0 +1,10 @@
+package com.emmsale.message_room.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class RoomQueryService {
+
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/application/RoomQueryService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/application/RoomQueryService.java
@@ -1,10 +1,38 @@
 package com.emmsale.message_room.application;
 
+import static com.emmsale.member.exception.MemberExceptionType.NOT_MATCHING_TOKEN_AND_LOGIN_MEMBER;
+
+import com.emmsale.member.domain.Member;
+import com.emmsale.member.exception.MemberException;
+import com.emmsale.message_room.application.dto.RoomResponse;
+import com.emmsale.message_room.infrastructure.persistence.MessageDao;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RoomQueryService {
 
+  private final MessageDao messageDao;
+
+  public List<RoomResponse> findAll(final Member loginMember, final Long memberId) {
+    validateSameMember(loginMember, memberId);
+
+    return messageDao.findRecentlyMessages(memberId)
+        .stream()
+        .map(RoomResponse::from)
+        .sorted(Comparator.comparing(RoomResponse::getRecentlyMessageTime).reversed())
+        .collect(Collectors.toList());
+  }
+
+  private void validateSameMember(final Member loginMember, final Long memberId) {
+    if (loginMember.isNotMe(memberId)) {
+      throw new MemberException(NOT_MATCHING_TOKEN_AND_LOGIN_MEMBER);
+    }
+  }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/application/dto/RoomResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/application/dto/RoomResponse.java
@@ -1,0 +1,27 @@
+package com.emmsale.message_room.application.dto;
+
+import com.emmsale.message_room.infrastructure.persistence.dto.MessageOverview;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class RoomResponse {
+
+  private final String roomId;
+  private final String senderName;
+  private final String recentlyMessage;
+  @JsonFormat(pattern = "yyyy:MM:dd:HH:mm:ss")
+  private final LocalDateTime recentlyMessageTime;
+
+  public static RoomResponse from(final MessageOverview messageOverview) {
+    return new RoomResponse(
+        messageOverview.getRoomId(),
+        messageOverview.getSenderName(),
+        messageOverview.getContent(),
+        messageOverview.getCreatedAt()
+    );
+  }
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/application/dto/RoomResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/application/dto/RoomResponse.java
@@ -1,5 +1,6 @@
 package com.emmsale.message_room.application.dto;
 
+import com.emmsale.member.domain.Member;
 import com.emmsale.message_room.infrastructure.persistence.dto.MessageOverview;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
@@ -11,15 +12,20 @@ import lombok.RequiredArgsConstructor;
 public class RoomResponse {
 
   private final String roomId;
-  private final String senderName;
+  private final Long interlocutorId;
+  private final String interlocutorName;
   private final String recentlyMessage;
   @JsonFormat(pattern = "yyyy:MM:dd:HH:mm:ss")
   private final LocalDateTime recentlyMessageTime;
 
-  public static RoomResponse from(final MessageOverview messageOverview) {
+  public static RoomResponse from(
+      final MessageOverview messageOverview,
+      final Member interlocutor
+  ) {
     return new RoomResponse(
-        messageOverview.getRoomId(),
-        messageOverview.getSenderName(),
+        messageOverview.getRoomUUID(),
+        interlocutor.getId(),
+        interlocutor.getName(),
         messageOverview.getContent(),
         messageOverview.getCreatedAt()
     );

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/Message.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/Message.java
@@ -1,4 +1,4 @@
-package com.emmsale.message.domain;
+package com.emmsale.message_room.domain;
 
 import java.time.LocalDateTime;
 import javax.persistence.Column;

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/Message.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/Message.java
@@ -3,12 +3,9 @@ package com.emmsale.message_room.domain;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,21 +25,20 @@ public class Message {
   @Column(nullable = false)
   private Long senderId;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
-  private Room room;
+  @Column(nullable = false)
+  private String roomId;
 
   private LocalDateTime createdAt;
 
   public Message(
       final String content,
       final Long senderId,
-      final Room room,
+      final String roomId,
       final LocalDateTime createdAt
   ) {
     this.content = content;
     this.senderId = senderId;
-    this.room = room;
+    this.roomId = roomId;
     this.createdAt = createdAt;
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/Message.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/Message.java
@@ -37,11 +37,12 @@ public class Message {
   public Message(
       final String content,
       final Long senderId,
-      final Room room
+      final Room room,
+      final LocalDateTime createdAt
   ) {
     this.content = content;
     this.senderId = senderId;
     this.room = room;
-    this.createdAt = LocalDateTime.now();
+    this.createdAt = createdAt;
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/MessageRepository.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/MessageRepository.java
@@ -1,0 +1,7 @@
+package com.emmsale.message_room.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/Room.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/Room.java
@@ -1,11 +1,15 @@
 package com.emmsale.message_room.domain;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,6 +34,9 @@ public class Room {
 
   @Column(nullable = false)
   private LocalDateTime receiverLastExitedTime;
+
+  @OneToMany(fetch = FetchType.LAZY, mappedBy = "room")
+  private List<Message> messages = new ArrayList<>();
 
   public Room(
       final Long requesterId,

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/Room.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/Room.java
@@ -1,4 +1,4 @@
-package com.emmsale.message.domain;
+package com.emmsale.message_room.domain;
 
 import java.time.LocalDateTime;
 import javax.persistence.Column;

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/Room.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/Room.java
@@ -1,15 +1,8 @@
 package com.emmsale.message_room.domain;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,34 +12,13 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Room {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+  @EmbeddedId
+  private RoomId roomId;
 
-  @Column(nullable = false)
-  private Long requesterId;
+  private LocalDateTime lastExitedTime;
 
-  @Column(nullable = false)
-  private LocalDateTime requesterLastExitedTime;
-
-  @Column(nullable = false)
-  private Long receiverId;
-
-  @Column(nullable = false)
-  private LocalDateTime receiverLastExitedTime;
-
-  @OneToMany(fetch = FetchType.LAZY, mappedBy = "room")
-  private List<Message> messages = new ArrayList<>();
-
-  public Room(
-      final Long requesterId,
-      final LocalDateTime requesterLastExitedTime,
-      final Long receiverId,
-      final LocalDateTime receiverLastExitedTime
-  ) {
-    this.requesterId = requesterId;
-    this.requesterLastExitedTime = requesterLastExitedTime;
-    this.receiverId = receiverId;
-    this.receiverLastExitedTime = receiverLastExitedTime;
+  public Room(final RoomId roomId, final LocalDateTime lastExitedTime) {
+    this.roomId = roomId;
+    this.lastExitedTime = lastExitedTime;
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/Room.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/Room.java
@@ -21,4 +21,8 @@ public class Room {
     this.roomId = roomId;
     this.lastExitedTime = lastExitedTime;
   }
+
+  public boolean isInterlocutorWith(final Long loginMemberId) {
+    return roomId.isInterlocutors(loginMemberId);
+  }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/Room.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/Room.java
@@ -19,27 +19,27 @@ public class Room {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false, name = "member1_id")
-  private Long member1Id;
+  @Column(nullable = false)
+  private Long requesterId;
 
-  @Column(nullable = false, name = "member1_last_exited_time")
-  private LocalDateTime member1LastExitedTime;
+  @Column(nullable = false)
+  private LocalDateTime requesterLastExitedTime;
 
-  @Column(nullable = false, name = "member2_id")
-  private Long member2Id;
+  @Column(nullable = false)
+  private Long receiverId;
 
-  @Column(nullable = false, name = "member2_last_exited_time")
-  private LocalDateTime member2LastExitedTime;
+  @Column(nullable = false)
+  private LocalDateTime receiverLastExitedTime;
 
   public Room(
-      final Long member1Id,
-      final LocalDateTime member1LastExitedTime,
-      final Long member2Id,
-      final LocalDateTime member2LastExitedTime
+      final Long requesterId,
+      final LocalDateTime requesterLastExitedTime,
+      final Long receiverId,
+      final LocalDateTime receiverLastExitedTime
   ) {
-    this.member1Id = member1Id;
-    this.member1LastExitedTime = member1LastExitedTime;
-    this.member2Id = member2Id;
-    this.member2LastExitedTime = member2LastExitedTime;
+    this.requesterId = requesterId;
+    this.requesterLastExitedTime = requesterLastExitedTime;
+    this.receiverId = receiverId;
+    this.receiverLastExitedTime = receiverLastExitedTime;
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/RoomId.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/RoomId.java
@@ -1,0 +1,41 @@
+package com.emmsale.message_room.domain;
+
+import java.io.Serializable;
+import java.util.Objects;
+import javax.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoomId implements Serializable {
+
+  private String uuid;
+
+  private Long userId;
+
+  public RoomId(final String uuid, final Long userId) {
+    this.uuid = uuid;
+    this.userId = userId;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RoomId roomId = (RoomId) o;
+    return Objects.equals(uuid, roomId.uuid)
+        && Objects.equals(userId, roomId.userId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(uuid, userId);
+  }
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/RoomId.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/RoomId.java
@@ -14,11 +14,11 @@ public class RoomId implements Serializable {
 
   private String uuid;
 
-  private Long userId;
+  private Long memberId;
 
-  public RoomId(final String uuid, final Long userId) {
+  public RoomId(final String uuid, final Long memberId) {
     this.uuid = uuid;
-    this.userId = userId;
+    this.memberId = memberId;
   }
 
   @Override
@@ -31,11 +31,11 @@ public class RoomId implements Serializable {
     }
     final RoomId roomId = (RoomId) o;
     return Objects.equals(uuid, roomId.uuid)
-        && Objects.equals(userId, roomId.userId);
+        && Objects.equals(memberId, roomId.memberId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(uuid, userId);
+    return Objects.hash(uuid, memberId);
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/RoomId.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/RoomId.java
@@ -21,6 +21,10 @@ public class RoomId implements Serializable {
     this.memberId = memberId;
   }
 
+  public boolean isInterlocutors(final Long loginMemberId) {
+    return !memberId.equals(loginMemberId);
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/RoomRepository.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/RoomRepository.java
@@ -2,6 +2,6 @@ package com.emmsale.message_room.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RoomRepository extends JpaRepository<Room, Long> {
+public interface RoomRepository extends JpaRepository<Room, RoomId> {
 
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/RoomRepository.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/RoomRepository.java
@@ -1,7 +1,11 @@
 package com.emmsale.message_room.domain;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface RoomRepository extends JpaRepository<Room, RoomId> {
 
+  @Query("select r from Room r where r.roomId.uuid = :uuid")
+  List<Room> findByUUID(final String uuid);
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/RoomRepository.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/domain/RoomRepository.java
@@ -1,0 +1,7 @@
+package com.emmsale.message_room.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomRepository extends JpaRepository<Room, Long> {
+
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/infrastructure/persistence/MessageDao.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/infrastructure/persistence/MessageDao.java
@@ -1,0 +1,44 @@
+package com.emmsale.message_room.infrastructure.persistence;
+
+
+import com.emmsale.message_room.infrastructure.persistence.dto.MessageOverview;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MessageDao {
+
+  private static final RowMapper<MessageOverview> ROW_MAPPER = (rs, rowNum) ->
+      new MessageOverview(
+          rs.getLong("id"),
+          rs.getString("content"),
+          rs.getTimestamp("created_at").toLocalDateTime(),
+          rs.getLong("sender_id"),
+          rs.getString("room_id"),
+          rs.getString("name")
+      );
+
+  private final JdbcTemplate jdbcTemplate;
+
+  public List<MessageOverview> findRecentlyMessages(final Long memberId) {
+    StringBuilder sqlBuilder = new StringBuilder();
+
+    sqlBuilder
+        .append("SELECT m2.id, m2.content, m2.created_at, m2.sender_id, m2.room_id, mem.name ")
+        .append("FROM room r ")
+        .append("JOIN (SELECT room_id, MAX(created_at) as max_created_at ")
+        .append("      FROM message ")
+        .append("      GROUP BY room_id) m1 ON r.uuid = m1.room_id ")
+        .append("JOIN message m2 ON m1.room_id = m2.room_id AND m1.max_created_at = m2.created_at ")
+        .append("JOIN member mem on m2.sender_id = mem.id ")
+        .append("WHERE r.member_id = ? ")
+        .append("AND m2.created_at > r.last_exited_time ")
+        .append("ORDER BY m2.created_at DESC");
+
+    return jdbcTemplate.query(sqlBuilder.toString(), ROW_MAPPER, memberId);
+  }
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/infrastructure/persistence/MessageDao.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/infrastructure/persistence/MessageDao.java
@@ -17,9 +17,7 @@ public class MessageDao {
           rs.getLong("id"),
           rs.getString("content"),
           rs.getTimestamp("created_at").toLocalDateTime(),
-          rs.getLong("sender_id"),
-          rs.getString("room_id"),
-          rs.getString("name")
+          rs.getString("room_id")
       );
 
   private final JdbcTemplate jdbcTemplate;
@@ -28,13 +26,12 @@ public class MessageDao {
     StringBuilder sqlBuilder = new StringBuilder();
 
     sqlBuilder
-        .append("SELECT m2.id, m2.content, m2.created_at, m2.sender_id, m2.room_id, mem.name ")
+        .append("SELECT m2.id, m2.content, m2.created_at, m2.room_id ")
         .append("FROM room r ")
         .append("JOIN (SELECT room_id, MAX(created_at) as max_created_at ")
         .append("      FROM message ")
         .append("      GROUP BY room_id) m1 ON r.uuid = m1.room_id ")
         .append("JOIN message m2 ON m1.room_id = m2.room_id AND m1.max_created_at = m2.created_at ")
-        .append("JOIN member mem on m2.sender_id = mem.id ")
         .append("WHERE r.member_id = ? ")
         .append("AND m2.created_at > r.last_exited_time ")
         .append("ORDER BY m2.created_at DESC");

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/infrastructure/persistence/dto/MessageOverview.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/infrastructure/persistence/dto/MessageOverview.java
@@ -1,0 +1,17 @@
+package com.emmsale.message_room.infrastructure.persistence.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class MessageOverview {
+
+  private final Long id;
+  private final String content;
+  private final LocalDateTime createdAt;
+  private final Long senderId;
+  private final String roomId;
+  private final String senderName;
+}

--- a/backend/emm-sale/src/main/java/com/emmsale/message_room/infrastructure/persistence/dto/MessageOverview.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/message_room/infrastructure/persistence/dto/MessageOverview.java
@@ -11,7 +11,5 @@ public class MessageOverview {
   private final Long id;
   private final String content;
   private final LocalDateTime createdAt;
-  private final Long senderId;
-  private final String roomId;
-  private final String senderName;
+  private final String roomUUID;
 }

--- a/backend/emm-sale/src/main/resources/data.sql
+++ b/backend/emm-sale/src/main/resources/data.sql
@@ -13,6 +13,8 @@ truncate table update_notification;
 truncate table block;
 truncate table report;
 truncate table scrap;
+truncate table message;
+truncate table room;
 
 insert into activity(id, type, name)
 values (1, 'CLUB', 'YAPP');

--- a/backend/emm-sale/src/main/resources/schema.sql
+++ b/backend/emm-sale/src/main/resources/schema.sql
@@ -193,12 +193,10 @@ alter table member
 
 create table room
 (
-    id                         bigint not null auto_increment,
-    requester_id               bigint not null,
-    requester_last_exited_time datetime(6) not null,
-    receiver_id                bigint not null,
-    receiver_last_exited_time  datetime(6) not null,
-    primary key (id)
+    uuid             varchar(40) not null,
+    user_id          bigint      not null,
+    last_exited_time datetime(6),
+    primary key (uuid, user_id)
 );
 
 create table message
@@ -207,6 +205,6 @@ create table message
     content    varchar(255) not null,
     created_at datetime(6),
     sender_id  bigint       not null,
-    room_id    bigint       not null,
+    room_id    varchar(40)  not null,
     primary key (id)
 );

--- a/backend/emm-sale/src/main/resources/schema.sql
+++ b/backend/emm-sale/src/main/resources/schema.sql
@@ -28,11 +28,11 @@ create table event
     id              bigint auto_increment primary key,
     created_at      datetime(6),
     updated_at      datetime(6),
-    end_date        datetime(6)  not null,
+    end_date        datetime(6) not null,
     information_url varchar(255) not null,
     location        varchar(255) not null,
     name            varchar(255) not null,
-    start_date      datetime(6)  not null,
+    start_date      datetime(6) not null,
     image_url       varchar(255),
     type            varchar(20)  not null
 );
@@ -58,7 +58,7 @@ create table comment
     is_deleted bit          not null,
     event_id   bigint       not null,
     member_id  bigint       not null,
-    parent_id  bigint       null
+    parent_id  bigint null
 );
 
 create table member_activity
@@ -126,7 +126,8 @@ alter table event_member
     add column updated_at datetime(6);
 
 -- 2023.08.08 17:04
-rename table notification TO request_notification;
+rename
+table notification TO request_notification;
 
 create table update_notification
 (
@@ -141,8 +142,8 @@ create table update_notification
 create table block
 (
     id                bigint auto_increment primary key,
-    block_member_id   bigint      not null,
-    request_member_id bigint      not null,
+    block_member_id   bigint not null,
+    request_member_id bigint not null,
     created_at        datetime(6) null,
     updated_at        datetime(6) null
 );
@@ -192,11 +193,11 @@ alter table member
 
 create table room
 (
-    id                       bigint      not null auto_increment,
-    member1_id               bigint      not null,
-    member1_last_exited_time datetime(6) not null,
-    member2_id               bigint      not null,
-    member2_last_exited_time datetime(6) not null,
+    id                         bigint not null auto_increment,
+    requester_id               bigint not null,
+    requester_last_exited_time datetime(6) not null,
+    receiver_id                bigint not null,
+    receiver_last_exited_time  datetime(6) not null,
     primary key (id)
 );
 

--- a/backend/emm-sale/src/main/resources/schema.sql
+++ b/backend/emm-sale/src/main/resources/schema.sql
@@ -13,6 +13,8 @@ drop table if exists kerdy.block;
 drop table if exists kerdy.update_notification;
 drop table if exists kerdy.report;
 drop table if exists kerdy.scrap;
+drop table if exists kerdy.message;
+drop table if exists kerdy.room;
 
 create table activity
 (
@@ -185,3 +187,25 @@ create table report
 
 alter table member
     add column github_username varchar(40) not null default '';
+
+-- 2023-08-31 19:57
+
+create table room
+(
+    id                       bigint      not null auto_increment,
+    member1_id               bigint      not null,
+    member1_last_exited_time datetime(6) not null,
+    member2_id               bigint      not null,
+    member2_last_exited_time datetime(6) not null,
+    primary key (id)
+);
+
+create table message
+(
+    id         bigint       not null auto_increment,
+    content    varchar(255) not null,
+    created_at datetime(6),
+    sender_id  bigint       not null,
+    room_id    bigint       not null,
+    primary key (id)
+);

--- a/backend/emm-sale/src/main/resources/schema.sql
+++ b/backend/emm-sale/src/main/resources/schema.sql
@@ -194,9 +194,9 @@ alter table member
 create table room
 (
     uuid             varchar(40) not null,
-    user_id          bigint      not null,
+    member_id        bigint      not null,
     last_exited_time datetime(6),
-    primary key (uuid, user_id)
+    primary key (uuid, member_id)
 );
 
 create table message

--- a/backend/emm-sale/src/test/java/com/emmsale/message_room/application/RoomQueryServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/message_room/application/RoomQueryServiceTest.java
@@ -1,0 +1,125 @@
+package com.emmsale.message_room.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.emmsale.helper.ServiceIntegrationTestHelper;
+import com.emmsale.member.domain.Member;
+import com.emmsale.member.domain.MemberRepository;
+import com.emmsale.message_room.application.dto.RoomResponse;
+import com.emmsale.message_room.domain.Message;
+import com.emmsale.message_room.domain.MessageRepository;
+import com.emmsale.message_room.domain.Room;
+import com.emmsale.message_room.domain.RoomId;
+import com.emmsale.message_room.domain.RoomRepository;
+import com.emmsale.message_room.infrastructure.persistence.dto.MessageOverview;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class RoomQueryServiceTest extends ServiceIntegrationTestHelper {
+
+  @Autowired
+  private RoomQueryService roomQueryService;
+  @Autowired
+  private RoomRepository roomRepository;
+  @Autowired
+  private MessageRepository messageRepository;
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @Test
+  @DisplayName("findAll() : 사용자가 중도에 나가는 Room에 상관없이 참여하고 있는 Room 중에서 가장 최근에 받은 메시지들을 조회할 수 있다.")
+  void test_findAll() throws Exception {
+    final Member member = memberRepository.findById(1L).get();
+    member.updateName("member1");
+    memberRepository.save(member);
+
+    roomRepository.saveAll(List.of(
+        new Room(new RoomId("feed014c-33f7-418c-8841-5553db5f22c1", member.getId()),
+            LocalDateTime.parse("2023-09-05T16:26:20.751352")),
+        new Room(new RoomId("feed014c-33f7-418c-8841-5553db5f22c1", 2L),
+            LocalDateTime.parse("2023-09-07T16:48:24")),
+        new Room(new RoomId("feed014c-33f7-418c-8841-5553db5f22c2", member.getId()),
+            LocalDateTime.parse("2023-09-07T16:48:24")),
+        new Room(new RoomId("feed014c-33f7-418c-8841-5553db5f22c2", 3L),
+            LocalDateTime.parse("2023-09-07T16:48:24")),
+        new Room(new RoomId("feed014c-33f7-418c-8841-5553db5f22c3", member.getId()),
+            LocalDateTime.parse("2023-10-07T16:48:24")),
+        new Room(new RoomId("feed014c-33f7-418c-8841-5553db5f22c3", 4L),
+            LocalDateTime.parse("2023-08-07T16:45:39"))
+    ));
+
+    final Message resultMessage1 = new Message(
+        "방1메시지3",
+        member.getId(),
+        "feed014c-33f7-418c-8841-5553db5f22c1",
+        LocalDateTime.parse("2023-10-07T16:45:39")
+    );
+    final Message resultMessage2 = new Message(
+        "방2메시지4",
+        3L,
+        "feed014c-33f7-418c-8841-5553db5f22c2",
+        LocalDateTime.parse("2023-10-07T16:45:39")
+    );
+    messageRepository.saveAll(
+        List.of(
+            new Message("방1메시지1", member.getId(), "feed014c-33f7-418c-8841-5553db5f22c1",
+                LocalDateTime.parse("2023-05-07T16:45:39")),
+            new Message("방1메시지2", member.getId(), "feed014c-33f7-418c-8841-5553db5f22c1",
+                LocalDateTime.parse("2023-06-07T16:45:39")),
+            resultMessage1,
+            resultMessage2,
+            new Message("방3메시지5", member.getId(), "feed014c-33f7-418c-8841-5553db5f22c3",
+                LocalDateTime.parse("2023-08-07T16:45:39"))
+        )
+    );
+
+    final Member member3 = new Member(3L, "image", "username3");
+    member3.updateName("member3");
+    memberRepository.save(member3);
+    final Member member4 = new Member(4L, "image", "username4");
+    member4.updateName("member4");
+    memberRepository.save(member4);
+    final Member member5 = new Member(5L, "image", "username5");
+    member5.updateName("member5");
+    memberRepository.save(member5);
+
+    final Member recentlyMessage1Owner =
+        memberRepository.findById(resultMessage1.getSenderId()).get();
+    final Member recentlyMessage2Owner =
+        memberRepository.findById(resultMessage2.getSenderId()).get();
+
+    final MessageOverview messageOverview1 = new MessageOverview(
+        resultMessage1.getId(),
+        resultMessage1.getContent(),
+        resultMessage1.getCreatedAt(),
+        recentlyMessage1Owner.getId(),
+        resultMessage1.getRoomId(),
+        recentlyMessage1Owner.getName()
+    );
+
+    final MessageOverview messageOverview2 = new MessageOverview(
+        resultMessage2.getId(),
+        resultMessage2.getContent(),
+        resultMessage2.getCreatedAt(),
+        resultMessage2.getId(),
+        resultMessage2.getRoomId(),
+        recentlyMessage2Owner.getName()
+    );
+
+    final List<RoomResponse> actual = List.of(
+        RoomResponse.from(messageOverview1),
+        RoomResponse.from(messageOverview2)
+    );
+
+    //when
+    final List<RoomResponse> expect = roomQueryService.findAll(member, member.getId());
+
+    //then
+    assertThat(actual)
+        .usingRecursiveComparison()
+        .isEqualTo(expect);
+  }
+}

--- a/backend/emm-sale/src/test/java/com/emmsale/message_room/application/RoomQueryServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/message_room/application/RoomQueryServiceTest.java
@@ -32,90 +32,92 @@ class RoomQueryServiceTest extends ServiceIntegrationTestHelper {
   @Test
   @DisplayName("findAll() : 사용자가 중도에 나가는 Room에 상관없이 참여하고 있는 Room 중에서 가장 최근에 받은 메시지들을 조회할 수 있다.")
   void test_findAll() throws Exception {
-    final Member member = memberRepository.findById(1L).get();
-    member.updateName("member1");
-    memberRepository.save(member);
+    final Member loginMember = memberRepository.findById(1L).get();
+    loginMember.updateName("member1");
+    memberRepository.save(loginMember);
+
+    final Member room1Interlocutor = new Member(3L, "image", "username3");
+    room1Interlocutor.updateName("room1Interlocutor");
+    memberRepository.save(room1Interlocutor);
+
+    final Member room2Interlocutor = new Member(4L, "image", "username4");
+    room2Interlocutor.updateName("room2Interlocutor");
+    memberRepository.save(room2Interlocutor);
+
+    final Member room3Interlocutor = new Member(5L, "image", "username5");
+    room3Interlocutor.updateName("room3Interlocutor");
+    memberRepository.save(room3Interlocutor);
+
+    final String room1UUID = "feed014c-33f7-418c-8841-5553db5f22c1";
+    final String room2UUID = "feed014c-33f7-418c-8841-5553db5f22c2";
+    final String room3UUID = "feed014c-33f7-418c-8841-5553db5f22c3";
 
     roomRepository.saveAll(List.of(
-        new Room(new RoomId("feed014c-33f7-418c-8841-5553db5f22c1", member.getId()),
+        new Room(new RoomId(room1UUID, loginMember.getId()),
             LocalDateTime.parse("2023-09-05T16:26:20.751352")),
-        new Room(new RoomId("feed014c-33f7-418c-8841-5553db5f22c1", 2L),
+        new Room(new RoomId(room1UUID, room1Interlocutor.getId()),
             LocalDateTime.parse("2023-09-07T16:48:24")),
-        new Room(new RoomId("feed014c-33f7-418c-8841-5553db5f22c2", member.getId()),
+
+        new Room(new RoomId(room2UUID, loginMember.getId()),
             LocalDateTime.parse("2023-09-07T16:48:24")),
-        new Room(new RoomId("feed014c-33f7-418c-8841-5553db5f22c2", 3L),
+        new Room(new RoomId(room2UUID, room2Interlocutor.getId()),
             LocalDateTime.parse("2023-09-07T16:48:24")),
-        new Room(new RoomId("feed014c-33f7-418c-8841-5553db5f22c3", member.getId()),
+
+        new Room(new RoomId(room3UUID, loginMember.getId()),
             LocalDateTime.parse("2023-10-07T16:48:24")),
-        new Room(new RoomId("feed014c-33f7-418c-8841-5553db5f22c3", 4L),
+        new Room(new RoomId(room3UUID, room3Interlocutor.getId()),
             LocalDateTime.parse("2023-08-07T16:45:39"))
     ));
 
     final Message resultMessage1 = new Message(
         "방1메시지3",
-        member.getId(),
-        "feed014c-33f7-418c-8841-5553db5f22c1",
+        loginMember.getId(),
+        room1UUID,
         LocalDateTime.parse("2023-10-07T16:45:39")
     );
     final Message resultMessage2 = new Message(
         "방2메시지4",
-        3L,
-        "feed014c-33f7-418c-8841-5553db5f22c2",
+        room2Interlocutor.getId(),
+        room2UUID,
         LocalDateTime.parse("2023-10-07T16:45:39")
     );
+
     messageRepository.saveAll(
         List.of(
-            new Message("방1메시지1", member.getId(), "feed014c-33f7-418c-8841-5553db5f22c1",
+            new Message("방1메시지1", loginMember.getId(), room1UUID,
                 LocalDateTime.parse("2023-05-07T16:45:39")),
-            new Message("방1메시지2", member.getId(), "feed014c-33f7-418c-8841-5553db5f22c1",
+            new Message("방1메시지2", loginMember.getId(), room1UUID,
                 LocalDateTime.parse("2023-06-07T16:45:39")),
             resultMessage1,
             resultMessage2,
-            new Message("방3메시지5", member.getId(), "feed014c-33f7-418c-8841-5553db5f22c3",
+            new Message("방3메시지5", loginMember.getId(), room3UUID,
                 LocalDateTime.parse("2023-08-07T16:45:39"))
         )
     );
-
-    final Member member3 = new Member(3L, "image", "username3");
-    member3.updateName("member3");
-    memberRepository.save(member3);
-    final Member member4 = new Member(4L, "image", "username4");
-    member4.updateName("member4");
-    memberRepository.save(member4);
-    final Member member5 = new Member(5L, "image", "username5");
-    member5.updateName("member5");
-    memberRepository.save(member5);
-
-    final Member recentlyMessage1Owner =
-        memberRepository.findById(resultMessage1.getSenderId()).get();
-    final Member recentlyMessage2Owner =
-        memberRepository.findById(resultMessage2.getSenderId()).get();
 
     final MessageOverview messageOverview1 = new MessageOverview(
         resultMessage1.getId(),
         resultMessage1.getContent(),
         resultMessage1.getCreatedAt(),
-        recentlyMessage1Owner.getId(),
-        resultMessage1.getRoomId(),
-        recentlyMessage1Owner.getName()
+        resultMessage1.getRoomId()
     );
 
     final MessageOverview messageOverview2 = new MessageOverview(
         resultMessage2.getId(),
         resultMessage2.getContent(),
         resultMessage2.getCreatedAt(),
-        resultMessage2.getId(),
-        resultMessage2.getRoomId(),
-        recentlyMessage2Owner.getName()
+        resultMessage2.getRoomId()
     );
 
     final List<RoomResponse> actual = List.of(
-        RoomResponse.from(messageOverview1),
-        RoomResponse.from(messageOverview2)
-    );
+        RoomResponse.from(messageOverview1,
+            memberRepository.findById(room1Interlocutor.getId()).get()),
+        RoomResponse.from(messageOverview2,
+            memberRepository.findById(room2Interlocutor.getId()).get()
+        ));
 
     //when
-    final List<RoomResponse> expect = roomQueryService.findAll(member, member.getId());
+    final List<RoomResponse> expect = roomQueryService.findAll(loginMember, loginMember.getId());
 
     //then
     assertThat(actual)

--- a/backend/emm-sale/src/test/java/com/emmsale/message_room/domain/RoomRepositoryTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/message_room/domain/RoomRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.emmsale.message_room.domain;
+
+import com.emmsale.helper.JpaRepositorySliceTestHelper;
+import com.emmsale.member.domain.Member;
+import com.emmsale.member.domain.MemberRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class RoomRepositoryTest extends JpaRepositorySliceTestHelper {
+
+  @Autowired
+  private RoomRepository roomRepository;
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @Test
+  @DisplayName("findByUUID() : UUID를 통해서 Room을 조회할 수 있다.")
+  void test_findByUUID() throws Exception {
+    //given
+    final Member member1 = memberRepository.findById(1L).get();
+    final Member member2 = memberRepository.findById(2L).get();
+    final Member member3 = memberRepository.save(new Member(333L, "image", "usdafkl"));
+
+    final String room1UUID = "feed014c-33f7-418c-8841-5553db5f22c1";
+    final String room2UUID = "feed014c-33f7-418c-8841-5553db5f22c2";
+
+    final Room member1Room1 = new Room(new RoomId(room1UUID, member1.getId()),
+        LocalDateTime.parse("2023-09-05T16:26:20.751352"));
+    final Room member2Room1 = new Room(new RoomId(room1UUID, member2.getId()),
+        LocalDateTime.parse("2023-09-07T16:48:24"));
+    final Room member1Room2 = new Room(new RoomId(room2UUID, member1.getId()),
+        LocalDateTime.parse("2023-09-07T16:48:24"));
+    final Room member3Room2 = new Room(new RoomId(room2UUID, member3.getId()),
+        LocalDateTime.parse("2023-09-07T16:48:24"));
+
+    roomRepository.saveAll(List.of(member1Room1, member2Room1, member1Room2, member3Room2));
+
+    final List<Room> actual = List.of(member1Room1, member2Room1);
+
+    //when
+    final List<Room> expect = roomRepository.findByUUID(room1UUID);
+
+    //then
+    Assertions.assertThat(actual)
+        .usingRecursiveComparison()
+        .isEqualTo(expect);
+  }
+}

--- a/backend/emm-sale/src/test/java/com/emmsale/message_room/infrastructure/persistence/MessageDaoTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/message_room/infrastructure/persistence/MessageDaoTest.java
@@ -11,7 +11,6 @@ import com.emmsale.message_room.domain.RoomRepository;
 import com.emmsale.message_room.infrastructure.persistence.dto.MessageOverview;
 import java.time.LocalDateTime;
 import java.util.List;
-import javax.persistence.EntityManager;
 import javax.sql.DataSource;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,8 +30,6 @@ class MessageDaoTest extends JpaRepositorySliceTestHelper {
   @Autowired
   private DataSource dataSource;
   private MessageDao messageDao;
-  @Autowired
-  private EntityManager entityManager;
 
   @BeforeEach
   void init() {
@@ -43,8 +40,13 @@ class MessageDaoTest extends JpaRepositorySliceTestHelper {
   @DisplayName("findRecentlyMessages() : 사용자가 참여하고 있는 Room 중에서 가장 최근에 받은 메시지들을 조회할 수 있다.")
   void test_findRecentlyMessages() throws Exception {
     //given
-    final Member member = memberRepository.findById(1L).get();
-    member.updateName("member1");
+    final Member unsavedMember = new Member(
+        3333L,
+        "imageUrl",
+        "asdfdfas"
+    );
+    unsavedMember.updateName("member1");
+    final Member member = memberRepository.save(unsavedMember);
 
     roomRepository.saveAll(List.of(
         new Room(new RoomId("feed014c-33f7-418c-8841-5553db5f22c1", member.getId()),
@@ -92,9 +94,6 @@ class MessageDaoTest extends JpaRepositorySliceTestHelper {
         .updateName("member4");
     memberRepository.save(new Member(5L, "image", "username3"))
         .updateName("member5");
-
-    entityManager.flush();
-    entityManager.clear();
 
     final Member recentlyMessage1Owner =
         memberRepository.findById(resultMessage1.getSenderId()).get();

--- a/backend/emm-sale/src/test/java/com/emmsale/message_room/infrastructure/persistence/MessageDaoTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/message_room/infrastructure/persistence/MessageDaoTest.java
@@ -1,0 +1,125 @@
+package com.emmsale.message_room.infrastructure.persistence;
+
+import com.emmsale.helper.JpaRepositorySliceTestHelper;
+import com.emmsale.member.domain.Member;
+import com.emmsale.member.domain.MemberRepository;
+import com.emmsale.message_room.domain.Message;
+import com.emmsale.message_room.domain.MessageRepository;
+import com.emmsale.message_room.domain.Room;
+import com.emmsale.message_room.domain.RoomId;
+import com.emmsale.message_room.domain.RoomRepository;
+import com.emmsale.message_room.infrastructure.persistence.dto.MessageOverview;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.sql.DataSource;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.Rollback;
+
+class MessageDaoTest extends JpaRepositorySliceTestHelper {
+
+  @Autowired
+  private RoomRepository roomRepository;
+  @Autowired
+  private MessageRepository messageRepository;
+  @Autowired
+  private MemberRepository memberRepository;
+  @Autowired
+  private DataSource dataSource;
+  private MessageDao messageDao;
+  @Autowired
+  private EntityManager entityManager;
+
+  @BeforeEach
+  void init() {
+    messageDao = new MessageDao(new JdbcTemplate(dataSource));
+  }
+
+  @Test
+  @Rollback(value = false)
+  @DisplayName("findRecentlyMessages() : 사용자가 참여하고 있는 Room 중에서 가장 최근에 받은 메시지들을 조회할 수 있다.")
+  void test_findRecentlyMessages() throws Exception {
+    //given
+    final Member member = memberRepository.findById(1L).get();
+    member.updateName("member1");
+
+    roomRepository.saveAll(List.of(
+        new Room(new RoomId("feed014c-33f7-418c-8841-5553db5f22c1", member.getId()),
+            LocalDateTime.parse("2023-09-05T16:26:20.751352")),
+        new Room(new RoomId("feed014c-33f7-418c-8841-5553db5f22c1", 2L),
+            LocalDateTime.parse("2023-09-07T16:48:24")),
+        new Room(new RoomId("feed014c-33f7-418c-8841-5553db5f22c2", member.getId()),
+            LocalDateTime.parse("2023-09-07T16:48:24")),
+        new Room(new RoomId("feed014c-33f7-418c-8841-5553db5f22c2", 3L),
+            LocalDateTime.parse("2023-09-07T16:48:24")),
+        new Room(new RoomId("feed014c-33f7-418c-8841-5553db5f22c3", member.getId()),
+            LocalDateTime.parse("2023-10-07T16:48:24")),
+        new Room(new RoomId("feed014c-33f7-418c-8841-5553db5f22c3", 4L),
+            LocalDateTime.parse("2023-08-07T16:45:39"))
+    ));
+
+    final Message resultMessage1 = new Message(
+        "방1메시지3",
+        member.getId(),
+        "feed014c-33f7-418c-8841-5553db5f22c1",
+        LocalDateTime.parse("2023-10-07T16:45:39")
+    );
+    final Message resultMessage2 = new Message(
+        "방2메시지4",
+        3L,
+        "feed014c-33f7-418c-8841-5553db5f22c2",
+        LocalDateTime.parse("2023-10-07T16:45:39")
+    );
+    messageRepository.saveAll(
+        List.of(
+            new Message("방1메시지1", member.getId(), "feed014c-33f7-418c-8841-5553db5f22c1",
+                LocalDateTime.parse("2023-05-07T16:45:39")),
+            new Message("방1메시지2", member.getId(), "feed014c-33f7-418c-8841-5553db5f22c1",
+                LocalDateTime.parse("2023-06-07T16:45:39")),
+            resultMessage1,
+            resultMessage2,
+            new Message("방3메시지5", member.getId(), "feed014c-33f7-418c-8841-5553db5f22c3",
+                LocalDateTime.parse("2023-08-07T16:45:39"))
+        )
+    );
+
+    memberRepository.save(new Member(3L, "image", "username3"))
+        .updateName("member3");
+    memberRepository.save(new Member(4L, "image", "username3"))
+        .updateName("member4");
+    memberRepository.save(new Member(5L, "image", "username3"))
+        .updateName("member5");
+
+    entityManager.flush();
+    entityManager.clear();
+
+    final Member recentlyMessage1Owner =
+        memberRepository.findById(resultMessage1.getSenderId()).get();
+    final Member recentlyMessage2Owner =
+        memberRepository.findById(resultMessage2.getSenderId()).get();
+
+    final List<MessageOverview> actual = List.of(
+        new MessageOverview(
+            resultMessage1.getId(), resultMessage1.getContent(),
+            resultMessage1.getCreatedAt(), resultMessage1.getSenderId(),
+            resultMessage1.getRoomId(), recentlyMessage1Owner.getName()),
+        new MessageOverview(
+            resultMessage2.getId(), resultMessage2.getContent(),
+            resultMessage2.getCreatedAt(), resultMessage2.getSenderId(),
+            resultMessage2.getRoomId(), recentlyMessage2Owner.getName())
+    );
+
+    //when
+    final List<MessageOverview> expect = messageDao.findRecentlyMessages(member.getId());
+
+    //then
+    Assertions.assertThat(actual)
+        .usingRecursiveComparison()
+        .isEqualTo(expect);
+  }
+}

--- a/backend/emm-sale/src/test/java/com/emmsale/message_room/infrastructure/persistence/MessageDaoTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/message_room/infrastructure/persistence/MessageDaoTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.annotation.Rollback;
 
 class MessageDaoTest extends JpaRepositorySliceTestHelper {
 
@@ -41,7 +40,6 @@ class MessageDaoTest extends JpaRepositorySliceTestHelper {
   }
 
   @Test
-  @Rollback(value = false)
   @DisplayName("findRecentlyMessages() : 사용자가 참여하고 있는 Room 중에서 가장 최근에 받은 메시지들을 조회할 수 있다.")
   void test_findRecentlyMessages() throws Exception {
     //given

--- a/backend/emm-sale/src/test/resources/data-test.sql
+++ b/backend/emm-sale/src/test/resources/data-test.sql
@@ -13,6 +13,8 @@ truncate table block;
 truncate table fcm_token;
 truncate table report;
 truncate table scrap;
+truncate table message;
+truncate table room;
 
 insert into activity(id, type, name)
 values (1, 'CLUB', 'YAPP');


### PR DESCRIPTION
## #️⃣연관된 이슈
- #507

## 📝작업 내용

쪽지 목록함 조회하는 기능입니다.
최근 메시지 1개만을 보여주기 때문에 모든 메시지를 조회해서 애플리케이션 내에서 처리하는게 비효율적인 것 같아서,
native query 를 사용하여 조회했습니다.

엔티티 설계는 Room 과 Message가 있습니다.
Room 은 복합키로 (room_id, member_id)를 가지고 있습니다.
room_id는 UUID이구요.

Message는 room_id를 참조하고 있습니다.

이렇게 한 이유는 다대다 관계인데 1:N, N:1로 맵핑해도 Room이 가지는 칼럼이 id밖에 없습니다.
그래서 굳이 다대다를 풀 필요가 없다고 생각하여 이렇게 설계를 했습니다.


### 스크린샷 (선택)
![image](https://github.com/woowacourse-teams/2023-emmsale/assets/62413589/70f0cfd3-d47b-44c5-ad43-950f722d00a5)

![image](https://github.com/woowacourse-teams/2023-emmsale/assets/62413589/1956397d-8a43-4ca4-9ccd-c985a9f72624)


