### PR TITLE
Feature/#532 call adapter 구현

### DIFF
--- a/android/2023-emmsale/app/proguard-rules.pro
+++ b/android/2023-emmsale/app/proguard-rules.pro
@@ -23,3 +23,4 @@
 
 # Keep the InterestEventTagUpdateResponseApiModel class itself and its fields from obfuscation
 -keep class com.emmsale.data.eventTag.remote.dto.InterestEventTagUpdateResponseApiModel { *; }
+-keep class com.emmsale.data.common.callAdapter.* { *; }

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/ServiceFactory.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/ServiceFactory.kt
@@ -1,6 +1,7 @@
 package com.emmsale.data.common
 
 import com.emmsale.BuildConfig
+import com.emmsale.data.common.callAdapter.KerdyCallAdapterFactory
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
@@ -33,6 +34,7 @@ class ServiceFactory {
     private val retrofit: Retrofit = Retrofit.Builder()
         .baseUrl(BASE_URL)
         .addConverterFactory(jsonConverterFactory)
+        .addCallAdapterFactory(KerdyCallAdapterFactory())
         .client(okhttpClient)
         .build()
 

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/callAdapter/ApiResponse.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/callAdapter/ApiResponse.kt
@@ -1,15 +1,18 @@
 package com.emmsale.data.common.callAdapter
 
+import okhttp3.Headers
+import okhttp3.internal.EMPTY_HEADERS
+
 sealed class ApiResponse<out T : Any> {
     fun <R : Any> map(transform: (T) -> R): ApiResponse<R> = when (this) {
-        is Success -> Success(transform(data))
+        is Success -> Success(transform(data), headers)
         is Failure -> Failure(code, message)
         is NetworkError -> NetworkError
         is Unexpected -> Unexpected(error)
     }
 }
 
-data class Success<T : Any>(val data: T) : ApiResponse<T>()
+data class Success<T : Any>(val data: T, val headers: Headers = EMPTY_HEADERS) : ApiResponse<T>()
 data class Failure(val code: Int, val message: String?) : ApiResponse<Nothing>()
 object NetworkError : ApiResponse<Nothing>()
 data class Unexpected(val error: Throwable?) : ApiResponse<Nothing>()

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/callAdapter/ApiResponse.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/callAdapter/ApiResponse.kt
@@ -1,6 +1,14 @@
 package com.emmsale.data.common.callAdapter
 
-sealed class ApiResponse<out T : Any>
+sealed class ApiResponse<out T : Any> {
+    fun <R : Any> map(transform: (T) -> R): ApiResponse<R> = when (this) {
+        is Success -> Success(transform(data))
+        is Failure -> Failure(responseCode, message)
+        is NetworkError -> NetworkError
+        is Unexpected -> Unexpected(error)
+    }
+}
+
 data class Success<T : Any>(val data: T) : ApiResponse<T>()
 data class Failure(val responseCode: Int, val message: String?) : ApiResponse<Nothing>()
 object NetworkError : ApiResponse<Nothing>()

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/callAdapter/ApiResponse.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/callAdapter/ApiResponse.kt
@@ -3,13 +3,13 @@ package com.emmsale.data.common.callAdapter
 sealed class ApiResponse<out T : Any> {
     fun <R : Any> map(transform: (T) -> R): ApiResponse<R> = when (this) {
         is Success -> Success(transform(data))
-        is Failure -> Failure(responseCode, message)
+        is Failure -> Failure(code, message)
         is NetworkError -> NetworkError
         is Unexpected -> Unexpected(error)
     }
 }
 
 data class Success<T : Any>(val data: T) : ApiResponse<T>()
-data class Failure(val responseCode: Int, val message: String?) : ApiResponse<Nothing>()
+data class Failure(val code: Int, val message: String?) : ApiResponse<Nothing>()
 object NetworkError : ApiResponse<Nothing>()
 data class Unexpected(val error: Throwable?) : ApiResponse<Nothing>()

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/callAdapter/ApiResult.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/callAdapter/ApiResult.kt
@@ -1,0 +1,7 @@
+package com.emmsale.data.common.callAdapter
+
+sealed class ApiResponse<out T : Any>
+data class Success<T : Any>(val data: T) : ApiResponse<T>()
+data class Failure(val responseCode: Int, val message: String?) : ApiResponse<Nothing>()
+object NetworkError : ApiResponse<Nothing>()
+data class Unexpected(val error: Throwable?) : ApiResponse<Nothing>()

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/callAdapter/KerdyCall.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/callAdapter/KerdyCall.kt
@@ -1,0 +1,59 @@
+package com.emmsale.data.common.callAdapter
+
+import okhttp3.Request
+import okio.Timeout
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import java.io.IOException
+import java.lang.reflect.Type
+
+class KerdyCall<T : Any>(
+    private val call: Call<T>,
+    private val responseType: Type,
+) : Call<ApiResponse<T>> {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun enqueue(callback: Callback<ApiResponse<T>>) {
+        call.enqueue(object : Callback<T> {
+            override fun onResponse(call: Call<T>, result: Response<T>) {
+                val apiResult = when {
+                    !result.isSuccessful -> Failure(result.code(), result.errorBody()?.string())
+                    responseType == Unit::class.java -> Success(Unit as T)
+                    result.body() == null -> Unexpected(IllegalStateException(NOT_EXIST_BODY))
+                    else -> Success(result.body()!!)
+                }
+                callback.onResponse(this@KerdyCall, Response.success(apiResult))
+            }
+
+            override fun onFailure(call: Call<T>, error: Throwable) {
+                val apiResult = when (error) {
+                    is IOException -> NetworkError
+                    else -> Unexpected(error)
+                }
+                callback.onResponse(this@KerdyCall, Response.success(apiResult))
+            }
+        })
+    }
+
+    override fun clone(): Call<ApiResponse<T>> = KerdyCall<T>(call.clone(), responseType)
+
+    override fun execute(): Response<ApiResponse<T>> {
+        throw UnsupportedOperationException(NOT_SUPPORT_EXECUTE)
+    }
+
+    override fun isExecuted(): Boolean = call.isExecuted
+
+    override fun cancel() = call.cancel()
+
+    override fun isCanceled(): Boolean = call.isCanceled
+
+    override fun request(): Request = call.request()
+
+    override fun timeout(): Timeout = call.timeout()
+
+    companion object {
+        private const val NOT_SUPPORT_EXECUTE = "[ERROR] Kerdy는 execute를 지원하지 않습니다."
+        private const val NOT_EXIST_BODY = "[ERROR] Response body가 존재하지 않습니다."
+    }
+}

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/callAdapter/KerdyCallAdapter.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/callAdapter/KerdyCallAdapter.kt
@@ -1,0 +1,14 @@
+package com.emmsale.data.common.callAdapter
+
+import retrofit2.Call
+import retrofit2.CallAdapter
+import java.lang.reflect.Type
+
+class KerdyCallAdapter<T : Any>(
+    private val responseType: Type,
+) : CallAdapter<T, Call<ApiResponse<T>>> {
+
+    override fun responseType(): Type = responseType
+
+    override fun adapt(call: Call<T>): Call<ApiResponse<T>> = KerdyCall(call, responseType)
+}

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/callAdapter/KerdyCallAdapterFactory.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/callAdapter/KerdyCallAdapterFactory.kt
@@ -1,0 +1,31 @@
+package com.emmsale.data.common.callAdapter
+
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.CallAdapter.Factory
+import retrofit2.Retrofit
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+class KerdyCallAdapterFactory : Factory() {
+
+    override fun get(
+        returnType: Type,
+        annotations: Array<out Annotation>,
+        retrofit: Retrofit,
+    ): CallAdapter<*, *>? {
+        if (getRawType(returnType) != Call::class.java) return null // Call
+        check(returnType is ParameterizedType) { NOT_GENERIC_TYPE.format(returnType) }
+
+        val responseType = getParameterUpperBound(0, returnType) // ApiResponse
+        if (getRawType(responseType) != ApiResponse::class.java) return null
+        check(responseType is ParameterizedType) { NOT_GENERIC_TYPE.format(responseType) }
+
+        val genericType = getParameterUpperBound(0, responseType) // DTO
+        return KerdyCallAdapter<Any>(genericType)
+    }
+
+    companion object {
+        private const val NOT_GENERIC_TYPE = "[ERROR] Generic 타입이어야 합니다."
+    }
+}

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/eventdetail/EventDetailRepository.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/eventdetail/EventDetailRepository.kt
@@ -1,7 +1,7 @@
 package com.emmsale.data.eventdetail
 
-import com.emmsale.data.common.ApiResult
+import com.emmsale.data.common.callAdapter.ApiResponse
 
 interface EventDetailRepository {
-    suspend fun getEventDetail(eventId: Long): ApiResult<EventDetail>
+    suspend fun getEventDetail(eventId: Long): ApiResponse<EventDetail>
 }

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/eventdetail/EventDetailRepositoryImpl.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/eventdetail/EventDetailRepositoryImpl.kt
@@ -1,17 +1,15 @@
 package com.emmsale.data.eventdetail
 
-import com.emmsale.data.common.ApiResult
-import com.emmsale.data.common.handleApi
+import com.emmsale.data.common.callAdapter.ApiResponse
 import com.emmsale.data.eventdetail.dto.EventDetailApiModel
 import com.emmsale.data.eventdetail.mapper.toData
 
 class EventDetailRepositoryImpl(
     private val eventDetailService: EventDetailService,
 ) : EventDetailRepository {
-    override suspend fun getEventDetail(eventId: Long): ApiResult<EventDetail> {
-        return handleApi(
-            execute = { eventDetailService.getEventDetail(eventId) },
-            mapToDomain = EventDetailApiModel::toData,
-        )
+    override suspend fun getEventDetail(eventId: Long): ApiResponse<EventDetail> {
+        return eventDetailService
+            .getEventDetail(eventId)
+            .map(EventDetailApiModel::toData)
     }
 }

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/eventdetail/EventDetailService.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/eventdetail/EventDetailService.kt
@@ -1,7 +1,7 @@
 package com.emmsale.data.eventdetail
 
+import com.emmsale.data.common.callAdapter.ApiResponse
 import com.emmsale.data.eventdetail.dto.EventDetailApiModel
-import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Path
 
@@ -9,5 +9,5 @@ interface EventDetailService {
     @GET("events/{eventId}")
     suspend fun getEventDetail(
         @Path("eventId") eventId: Long,
-    ): Response<EventDetailApiModel>
+    ): ApiResponse<EventDetailApiModel>
 }

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/eventdetail/EventDetailViewModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/eventdetail/EventDetailViewModel.kt
@@ -2,9 +2,10 @@ package com.emmsale.presentation.ui.eventdetail
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.emmsale.data.common.ApiError
-import com.emmsale.data.common.ApiException
-import com.emmsale.data.common.ApiSuccess
+import com.emmsale.data.common.callAdapter.Failure
+import com.emmsale.data.common.callAdapter.NetworkError
+import com.emmsale.data.common.callAdapter.Success
+import com.emmsale.data.common.callAdapter.Unexpected
 import com.emmsale.data.eventdetail.EventDetail
 import com.emmsale.data.eventdetail.EventDetailRepository
 import com.emmsale.presentation.KerdyApplication
@@ -33,9 +34,8 @@ class EventDetailViewModel(
         setLoadingState(true)
         viewModelScope.launch {
             when (val result = eventDetailRepository.getEventDetail(eventId)) {
-                is ApiSuccess -> fetchSuccessEventDetail(result.data)
-                is ApiError -> changeToErrorState()
-                is ApiException -> changeToErrorState()
+                is Success -> fetchSuccessEventDetail(result.data)
+                is Failure, NetworkError, is Unexpected -> changeToErrorState()
             }
         }
     }

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/RecruitmentNotificationViewModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationBox/recruitmentNotification/RecruitmentNotificationViewModel.kt
@@ -7,6 +7,10 @@ import androidx.lifecycle.viewModelScope
 import com.emmsale.data.common.ApiError
 import com.emmsale.data.common.ApiException
 import com.emmsale.data.common.ApiSuccess
+import com.emmsale.data.common.callAdapter.Failure
+import com.emmsale.data.common.callAdapter.NetworkError
+import com.emmsale.data.common.callAdapter.Success
+import com.emmsale.data.common.callAdapter.Unexpected
 import com.emmsale.data.eventdetail.EventDetailRepository
 import com.emmsale.data.member.MemberRepository
 import com.emmsale.data.notification.NotificationRepository
@@ -109,8 +113,8 @@ class RecruitmentNotificationViewModel(
     private suspend fun getConferenceNameAsync(conferenceId: Long): Deferred<String?> =
         viewModelScope.async {
             when (val conference = eventDetailRepository.getEventDetail(conferenceId)) {
-                is ApiSuccess -> conference.data.name
-                is ApiException, is ApiError -> null
+                is Success -> conference.data.name
+                is Failure, NetworkError, is Unexpected -> null
             }
         }
 

--- a/android/2023-emmsale/app/src/test/java/com/emmsale/presentation/ui/eventdetail/EventDetailViewModelTest.kt
+++ b/android/2023-emmsale/app/src/test/java/com/emmsale/presentation/ui/eventdetail/EventDetailViewModelTest.kt
@@ -1,8 +1,8 @@
 package com.emmsale.presentation.ui.eventdetail
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import com.emmsale.data.common.ApiError
-import com.emmsale.data.common.ApiSuccess
+import com.emmsale.data.common.callAdapter.Failure
+import com.emmsale.data.common.callAdapter.Success
 import com.emmsale.data.eventdetail.EventDetail
 import com.emmsale.data.eventdetail.EventDetailRepository
 import io.mockk.coEvery
@@ -65,7 +65,7 @@ class EventDetailViewModelTest {
         coEvery {
             eventDetailRepository.getEventDetail(1L)
         } answers {
-            ApiSuccess(testEventDetail, Headers.headersOf("Auth", "hi"))
+            Success(testEventDetail, Headers.headersOf("Auth", "hi"))
         }
 
         // when
@@ -86,7 +86,7 @@ class EventDetailViewModelTest {
         coEvery {
             eventDetailRepository.getEventDetail(1L)
         } answers {
-            ApiError(code = 4548, message = null)
+            Failure(code = 4548, message = null)
         }
 
         // when


### PR DESCRIPTION
## #️⃣연관된 이슈
>  #532

## 📝작업 내용
> Call Adapter 구현

### 스크린샷 (선택)


## 예상 소요 시간 및 실제 소요 시간
> 1시간 / 3시간


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
해당 이슈에 CallAdapter를 각자 적용해주시면 됩니다.
[CallAdapter 적용 이슈](https://github.com/woowacourse-teams/2023-emmsale/issues/533)

ApiModel -> DataModel 변환에 대해 보일러 플레이트 코드를 줄이기 위해 ApiResponse에 map 함수를 구현하였습니다.
코드 사용법은 문서를 참고해주세요.