### PR TITLE
Feature/#559 행사에 여러 개 이미지 등록 기능 구현

### DIFF
--- a/backend/emm-sale/src/documentTest/asciidoc/index.adoc
+++ b/backend/emm-sale/src/documentTest/asciidoc/index.adoc
@@ -275,11 +275,16 @@ include::{snippets}/find-recruitment-post/response-fields.adoc[]
 
 === `POST` : 행사 생성
 
-.HTTP request
-include::{snippets}/add-event/http-request.adoc[]
+POST
+
+[source]
+----
+/events?name=인프콘 2023&location=코엑스&informationUrl=https://~~~&startDateTime=2023:06:01:12:00:00&endDateTime=2023:09:01:12:00:00&applyStartDateTime=2023:05:01:12:00:00&applyEndDateTime=2023:06:01:12:00:00&tags=백엔드,안드로이드&imageUrl=https://image.url&type=CONFERENCE&eventMode=ON_OFFLINE&paymentType=FREE
+----
 
 .HTTP request 설명
-include::{snippets}/add-event/request-fields.adoc[]
+include::{snippets}/add-event/request-parameters.adoc[]
+include::{snippets}/add-event/request-parts.adoc[]
 
 .HTTP response
 include::{snippets}/add-event/http-response.adoc[]

--- a/backend/emm-sale/src/documentTest/java/com/emmsale/EventApiTest.java
+++ b/backend/emm-sale/src/documentTest/java/com/emmsale/EventApiTest.java
@@ -29,6 +29,7 @@ import com.emmsale.tag.application.dto.TagRequest;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -85,7 +86,7 @@ class EventApiTest extends MockMvcTestHelper {
           .description("행사 신청 시작일까지 남은 일 수"),
       PayloadDocumentation.fieldWithPath("type").type(JsonFieldType.STRING)
           .description("event의 타입"),
-      PayloadDocumentation.fieldWithPath("imageUrls[]").description("이미지 URL들"));
+      PayloadDocumentation.fieldWithPath("imageUrls[]").description("이미지 URL들").optional());
 
   @Test
   @DisplayName("컨퍼런스의 상세정보를 조회할 수 있다.")
@@ -208,7 +209,7 @@ class EventApiTest extends MockMvcTestHelper {
         request.getApplyStartDateTime(), request.getApplyEndDateTime(),
         request.getLocation(), EventStatus.IN_PROGRESS.name(), EventStatus.ENDED.name(),
         tags.stream().map(TagRequest::getName).collect(Collectors.toList()), request.getImageUrl(),
-        10, 10, request.getType().toString(), null);
+        10, 10, request.getType().toString(), Collections.emptyList());
 
     Mockito.when(eventService.updateEvent(any(), any(),
         any())).thenReturn(response);

--- a/backend/emm-sale/src/documentTest/java/com/emmsale/EventApiTest.java
+++ b/backend/emm-sale/src/documentTest/java/com/emmsale/EventApiTest.java
@@ -55,7 +55,6 @@ import org.springframework.restdocs.request.RequestPartsSnippet;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
-import org.springframework.web.multipart.MultipartFile;
 
 @WebMvcTest(EventApi.class)
 class EventApiTest extends MockMvcTestHelper {
@@ -85,7 +84,8 @@ class EventApiTest extends MockMvcTestHelper {
       PayloadDocumentation.fieldWithPath("applyRemainingDays").type(JsonFieldType.NUMBER)
           .description("행사 신청 시작일까지 남은 일 수"),
       PayloadDocumentation.fieldWithPath("type").type(JsonFieldType.STRING)
-          .description("event의 타입"));
+          .description("event의 타입"),
+      PayloadDocumentation.fieldWithPath("imageUrls[]").description("이미지 URL들"));
 
   @Test
   @DisplayName("컨퍼런스의 상세정보를 조회할 수 있다.")
@@ -98,7 +98,8 @@ class EventApiTest extends MockMvcTestHelper {
         LocalDateTime.of(2023, 8, 15, 12, 0), "코엑스",
         "UPCOMING",
         "ENDED", List.of("코틀린", "백엔드", "안드로이드"),
-        "https://www.image.com", 2, -12, EventType.COMPETITION.toString());
+        "https://www.image.com", 2, -12, EventType.COMPETITION.toString(),
+        List.of("imageUrl1", "imageUrl2"));
 
     Mockito.when(eventService.findEvent(ArgumentMatchers.anyLong(), any()))
         .thenReturn(eventDetailResponse);
@@ -207,7 +208,8 @@ class EventApiTest extends MockMvcTestHelper {
         request.getApplyStartDateTime(), request.getApplyEndDateTime(),
         request.getLocation(), EventStatus.IN_PROGRESS.name(), EventStatus.ENDED.name(),
         tags.stream().map(TagRequest::getName).collect(Collectors.toList()), request.getImageUrl(),
-        10, 10, request.getType().toString());
+        10, 10, request.getType().toString(),
+        List.of("imageUrl1", "imageUrl2"));
 
     Mockito.when(eventService.updateEvent(any(), any(),
         any())).thenReturn(response);
@@ -293,7 +295,8 @@ class EventApiTest extends MockMvcTestHelper {
           request.getApplyStartDateTime(), request.getApplyEndDateTime(),
           request.getLocation(), EventStatus.IN_PROGRESS.name(), EventStatus.ENDED.name(),
           tags.stream().map(TagRequest::getName).collect(Collectors.toList()),
-          request.getImageUrl(), 10, 10, request.getType().toString());
+          request.getImageUrl(), 10, 10, request.getType().toString(),
+          List.of("imageUrl1", "imageUrl2"));
 
       Mockito.when(eventService.addEvent(any(), any()))
           .thenReturn(response);

--- a/backend/emm-sale/src/documentTest/java/com/emmsale/EventApiTest.java
+++ b/backend/emm-sale/src/documentTest/java/com/emmsale/EventApiTest.java
@@ -208,8 +208,7 @@ class EventApiTest extends MockMvcTestHelper {
         request.getApplyStartDateTime(), request.getApplyEndDateTime(),
         request.getLocation(), EventStatus.IN_PROGRESS.name(), EventStatus.ENDED.name(),
         tags.stream().map(TagRequest::getName).collect(Collectors.toList()), request.getImageUrl(),
-        10, 10, request.getType().toString(),
-        List.of("imageUrl1", "imageUrl2"));
+        10, 10, request.getType().toString(), null);
 
     Mockito.when(eventService.updateEvent(any(), any(),
         any())).thenReturn(response);

--- a/backend/emm-sale/src/main/java/com/emmsale/GlobalControllerAdvice.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/GlobalControllerAdvice.java
@@ -8,6 +8,8 @@ import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -54,6 +56,13 @@ public class GlobalControllerAdvice {
   @ExceptionHandler(MissingServletRequestParameterException.class)
   public ResponseEntity<ExceptionResponse> handleMissingServletRequestParameterException(
       final MissingServletRequestParameterException e) {
+    final String message = "요청 파라미터가 올바르지 않습니다.";
+    log.warn("[WARN] MESSAGE: " + message);
+    return new ResponseEntity<>(new ExceptionResponse(message), HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(BindException.class)
+  public ResponseEntity<ExceptionResponse> handleBindExceptionHandler(final BindException e) {
     final String message = "요청 파라미터가 올바르지 않습니다.";
     log.warn("[WARN] MESSAGE: " + message);
     return new ResponseEntity<>(new ExceptionResponse(message), HttpStatus.BAD_REQUEST);

--- a/backend/emm-sale/src/main/java/com/emmsale/GlobalControllerAdvice.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/GlobalControllerAdvice.java
@@ -8,7 +8,6 @@ import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;

--- a/backend/emm-sale/src/main/java/com/emmsale/event/api/EventApi.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/api/EventApi.java
@@ -48,8 +48,7 @@ public class EventApi {
 
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
-  public EventDetailResponse addEvent(
-      @RequestBody @Valid final EventDetailRequest request) {
+  public EventDetailResponse addEvent(@Valid final EventDetailRequest request) {
     return eventService.addEvent(request, LocalDate.now());
   }
 

--- a/backend/emm-sale/src/main/java/com/emmsale/event/application/EventService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/application/EventService.java
@@ -20,6 +20,10 @@ import com.emmsale.event.domain.repository.EventTagRepository;
 import com.emmsale.event.exception.EventException;
 import com.emmsale.event.exception.EventExceptionType;
 import com.emmsale.event_publisher.EventPublisher;
+import com.emmsale.image.application.ImageCommandService;
+import com.emmsale.image.domain.Image;
+import com.emmsale.image.domain.ImageType;
+import com.emmsale.image.domain.repository.ImageRepository;
 import com.emmsale.tag.application.dto.TagRequest;
 import com.emmsale.tag.domain.Tag;
 import com.emmsale.tag.domain.TagRepository;
@@ -47,12 +51,22 @@ public class EventService {
   private final EventTagRepository eventTagRepository;
   private final TagRepository tagRepository;
   private final EventPublisher eventPublisher;
+  private final ImageCommandService imageCommandService;
+  private final ImageRepository imageRepository;
 
   @Transactional(readOnly = true)
   public EventDetailResponse findEvent(final Long id, final LocalDate today) {
     final Event event = eventRepository.findById(id)
         .orElseThrow(() -> new EventException(NOT_FOUND_EVENT));
-    return EventDetailResponse.from(event, today);
+
+    final List<String> imageUrls = imageRepository
+        .findAllByTypeAndContentId(ImageType.EVENT, event.getId())
+        .stream()
+        .sorted(comparing(Image::getOrder))
+        .map(Image::getName)
+        .collect(toList());
+
+    return EventDetailResponse.from(event, today, imageUrls);
   }
 
   @Transactional(readOnly = true)
@@ -166,14 +180,19 @@ public class EventService {
 
   public EventDetailResponse addEvent(final EventDetailRequest request, final LocalDate today) {
     final Event event = eventRepository.save(request.toEvent());
-
     final List<Tag> tags = findAllPersistTagsOrElseThrow(request.getTags());
-
     event.addAllEventTags(tags);
+
+    final List<String> imageUrls = imageCommandService
+        .saveImages(ImageType.EVENT, event.getId(), request.getImages())
+        .stream()
+        .sorted(comparing(Image::getOrder))
+        .map(Image::getName)
+        .collect(toList());
 
     eventPublisher.publish(event);
 
-    return EventDetailResponse.from(event, today);
+    return EventDetailResponse.from(event, today, imageUrls);
   }
 
   public EventDetailResponse updateEvent(final Long eventId, final EventDetailRequest request,
@@ -196,7 +215,14 @@ public class EventService {
         tags
     );
 
-    return EventDetailResponse.from(updatedEvent, today);
+    final List<String> imageUrls = imageRepository
+        .findAllByTypeAndContentId(ImageType.EVENT, event.getId())
+        .stream()
+        .sorted(comparing(Image::getOrder))
+        .map(Image::getName)
+        .collect(toList());
+
+    return EventDetailResponse.from(updatedEvent, today, imageUrls);
   }
 
   public void deleteEvent(final Long eventId) {

--- a/backend/emm-sale/src/main/java/com/emmsale/event/application/dto/EventDetailRequest.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/application/dto/EventDetailRequest.java
@@ -12,10 +12,13 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Getter
+@Setter
 public class EventDetailRequest {
 
   private static final String DATE_TIME_FORMAT = "yyyy:MM:dd:HH:mm:ss";
@@ -47,6 +50,8 @@ public class EventDetailRequest {
 
   private final EventMode eventMode;
   private final PaymentType paymentType;
+
+  private final List<MultipartFile> images;
 
   public Event toEvent() {
     return new Event(

--- a/backend/emm-sale/src/main/java/com/emmsale/event/application/dto/EventDetailResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/application/dto/EventDetailResponse.java
@@ -37,8 +37,13 @@ public class EventDetailResponse {
   private final Integer remainingDays;
   private final Integer applyRemainingDays;
   private final String type;
+  private final List<String> imageUrls;
 
-  public static EventDetailResponse from(final Event event, final LocalDate today) {
+  public static EventDetailResponse from(
+      final Event event,
+      final LocalDate today,
+      final List<String> imageUrls
+  ) {
     final List<String> tagNames = event.getTags().stream()
         .map(EventTag::getTag)
         .map(Tag::getName)
@@ -59,7 +64,8 @@ public class EventDetailResponse {
         event.getImageUrl(),
         event.getEventPeriod().calculateRemainingDays(today),
         event.getEventPeriod().calculateApplyRemainingDays(today),
-        event.getType().toString()
+        event.getType().toString(),
+        imageUrls
     );
   }
 }

--- a/backend/emm-sale/src/test/java/com/emmsale/event/application/dto/EventDetailResponseTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/application/dto/EventDetailResponseTest.java
@@ -7,6 +7,7 @@ import com.emmsale.event.domain.Event;
 import com.emmsale.event.domain.EventStatus;
 import java.time.LocalDate;
 import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -18,6 +19,8 @@ class EventDetailResponseTest {
     //given
     final Event 구름톤 = EventFixture.구름톤();
     final LocalDate 날짜 = LocalDate.of(2023, 7, 1);
+    final List<String> imageUrls = List.of("imageUrl1", "imageUrl2");
+
     final EventDetailResponse expected = new EventDetailResponse(
         구름톤.getId(),
         구름톤.getName(),
@@ -32,11 +35,12 @@ class EventDetailResponseTest {
         Collections.emptyList(),
         구름톤.getImageUrl(),
         2, 2,
-        구름톤.getType().toString()
+        구름톤.getType().toString(),
+        imageUrls
     );
 
     //when
-    final EventDetailResponse actual = EventDetailResponse.from(구름톤, 날짜);
+    final EventDetailResponse actual = EventDetailResponse.from(구름톤, 날짜, imageUrls);
 
     //then
     assertThat(actual)

--- a/backend/emm-sale/src/test/java/com/emmsale/helper/ServiceIntegrationTestHelper.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/helper/ServiceIntegrationTestHelper.java
@@ -1,5 +1,6 @@
 package com.emmsale.helper;
 
+import com.emmsale.image.application.ImageCommandService;
 import com.emmsale.login.utils.GithubClient;
 import com.emmsale.notification.application.FirebaseCloudMessageClient;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -15,4 +16,6 @@ public abstract class ServiceIntegrationTestHelper {
   protected GithubClient githubClient;
   @MockBean
   protected FirebaseCloudMessageClient firebaseCloudMessageClient;
+  @MockBean
+  protected ImageCommandService imageCommandService;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- #559 

## 📝작업 내용
- 관리자 페이지에서 행사 등록 시 여러 개 이미지 저장하도록 수정
- 행사 상세 정보 조회 시 저장된 이미지 name 반환하도록 수정


## 예상 소요 시간 및 실제 소요 시간
9/21 예상
9/20 완료
