### PR TITLE
fix: 알림 보관함에서 스크롤시 팅기는 버그 수정

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationPageList/NotificationBoxFragmentStateAdapter.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/notificationPageList/NotificationBoxFragmentStateAdapter.kt
@@ -16,7 +16,7 @@ class NotificationBoxFragmentStateAdapter(
     }
 
     companion object {
-        private const val NOTIFICATION_BOX_TAB_COUNT = 2
+        private const val NOTIFICATION_BOX_TAB_COUNT = 1
         private const val PRIMARY_NOTIFICATION_TAB_POSITION = 0
 
         private const val INVALID_FRAGMENT_POSITION_MESSAGE =


### PR DESCRIPTION
## #️⃣연관된 이슈
>  #624

## 📝작업 내용
> FragmentStateAdapter의 사이즈를 1로 설정하였습니다.

### 스크린샷 (선택)


## 예상 소요 시간 및 실제 소요 시간
> 10분 / 10분


## 💬리뷰 요구사항(선택)

> 간단한 버그라 바로 머지하겠습니다.