### PR TITLE
fix(SplashActivity): 안드로이드 API 버전 31 미만인 기기에서 스플래시 화면 보여줄 때 앱이 터지는 버그 수정

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/splash/SplashActivity.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/splash/SplashActivity.kt
@@ -9,8 +9,8 @@ import android.os.Bundle
 import android.view.View
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.window.SplashScreenView
+import androidx.activity.ComponentActivity
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.animation.doOnEnd
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.emmsale.R
@@ -28,7 +28,7 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 @SuppressLint("CustomSplashScreen")
-class SplashActivity : AppCompatActivity() {
+class SplashActivity : ComponentActivity() {
     private val viewModel: SplashViewModel by viewModels()
     private val binding by lazy { ActivitySplashBinding.inflate(layoutInflater) }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
>  #630

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

SplashActivity가 AppCompatActivity가 아니라 ComponentActivity를 상속하도록 변경하여 Theme.AppCompat이나 이것을 상속한 테마를 필요로 하지 않도록 변경

### 스크린샷 (선택)


## 예상 소요 시간 및 실제 소요 시간
> 이슈의 예상 소요 시간과 실제 소요된 시간을 분 or 시간 or 일 단위로 작성해주세요.
> 
> ex) 예상시간/걸린시간 => 2시간/3시간
1초/1초

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요