### PR TITLE
fix: 채팅창 진입 시 맨 하단으로 이동하지 않는 버그 수정

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageList/MessageListActivity.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageList/MessageListActivity.kt
@@ -74,7 +74,14 @@ class MessageListActivity : AppCompatActivity() {
     }
 
     private fun scrollToEnd() {
-        binding.rvMessageList.scrollToPosition(viewModel.messages.value.messageSize - 1)
+        val lastPosition = viewModel.messages.value.messageSize - 1
+
+        // RecyclerView 버그로 scrollToPosition이 완전히 마지막으로 이동하지 않아서 아래와 같이 작성함.
+        binding.rvMessageList.scrollToPosition(lastPosition)
+        lifecycleScope.launch {
+            delay(50)
+            binding.rvMessageList.smoothScrollToPosition(lastPosition)
+        }
     }
 
     private fun smoothScrollToEnd() {


### PR DESCRIPTION
## #️⃣연관된 이슈
>  #638 

## 📝작업 내용
> 채팅창 진입 시 가장 하단으로 이동하지 않는 버그를 수정하였습니다.
찾아보니 RecyclerView 자체에 스크롤 버그가 있어 아래와 같은 방법을 사용하였습니다.

```kotlin
private fun scrollToEnd() {
        val lastPosition = viewModel.messages.value.messageSize - 1

        // RecyclerView 버그로 scrollToPosition이 완전히 마지막으로 이동하지 않아서 아래와 같이 작성함.
        binding.rvMessageList.scrollToPosition(lastPosition)
        lifecycleScope.launch {
            delay(50)
            binding.rvMessageList.smoothScrollToPosition(lastPosition)
        }
    }
```
어쩔 수 없이 한 번에 이해하기 힘든 코드라, 이후에 코드 파악을 위해 주석을 남겨놓았습니다.
의도하지는 않았지만, 하단 스크롤시 훨씬 부드러워 보입니다.

### 스크린샷 (선택)


## 예상 소요 시간 및 실제 소요 시간
> 30분


## 💬리뷰 요구사항(선택)

> 함께 수정한 버그이기 때문에 바로 merge합니다.