### PR TITLE
fix: 채팅 EditText 클릭시 키보드가 화면을 가리는 버그 수정

### DIFF
--- a/android/2023-emmsale/app/src/main/AndroidManifest.xml
+++ b/android/2023-emmsale/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
             android:name=".presentation.ui.messageList.MessageListActivity"
             android:launchMode="singleTask"
             android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustResize|stateVisible"
             tools:ignore="LockedOrientationActivity" />
         <activity
             android:name=".presentation.ui.postWriting.PostWritingActivity"


### PR DESCRIPTION
## #️⃣연관된 이슈
>  #639

## 📝작업 내용
> 최근 채팅이 키보드에 가리는 버그를 수정했습니다.
채팅방 Activity의 manifest에 아래 코드를 추가하여 Activity가 리사이징되도록 했습니다
`android:windowSoftInputMode="adjustResize|stateVisible"`

### 스크린샷 (선택)


## 예상 소요 시간 및 실제 소요 시간
> 20분

## 💬리뷰 요구사항(선택)

> 간단한 버그 수정이라 바로 merge하겠습니다.