### PR TITLE
refactor: 행사 신청 시작 및 종료 일자 추가 및 상태 제거

### DIFF
--- a/backend/emm-sale/src/documentTest/java/com/emmsale/EventApiTest.java
+++ b/backend/emm-sale/src/documentTest/java/com/emmsale/EventApiTest.java
@@ -131,46 +131,60 @@ class EventApiTest extends MockMvcTestHelper {
     );
 
     final ResponseFieldsSnippet responseFields = PayloadDocumentation.responseFields(
-        fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("행사 id"),
-        fieldWithPath("[].name").type(JsonFieldType.STRING).description("행사명"),
-        fieldWithPath("[].startDate").type(JsonFieldType.STRING)
+        PayloadDocumentation.fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("행사 id"),
+        PayloadDocumentation.fieldWithPath("[].name").type(JsonFieldType.STRING).description("행사명"),
+        PayloadDocumentation.fieldWithPath("[].eventStartDate").type(JsonFieldType.STRING)
             .description("행사 시작일(yyyy:MM:dd:HH:mm:ss)"),
-        fieldWithPath("[].endDate").type(JsonFieldType.STRING)
+        PayloadDocumentation.fieldWithPath("[].eventEndDate").type(JsonFieldType.STRING)
             .description("행사 마감일(yyyy:MM:dd:HH:mm:ss)"),
-        fieldWithPath("[].tags[]").type(JsonFieldType.ARRAY)
+        PayloadDocumentation.fieldWithPath("[].applyStartDate").type(JsonFieldType.STRING)
+            .description("행사 시작일(yyyy:MM:dd:HH:mm:ss)"),
+        PayloadDocumentation.fieldWithPath("[].applyEndDate").type(JsonFieldType.STRING)
+            .description("행사 마감일(yyyy:MM:dd:HH:mm:ss)"),
+        PayloadDocumentation.fieldWithPath("[].tags[]").type(JsonFieldType.ARRAY)
             .description("행사 태그 목록"),
-        fieldWithPath("[].status").type(JsonFieldType.STRING)
-            .description("행사 진행 상황(IN_PROGRESS, UPCOMING, ENDED)"),
-        fieldWithPath("[].applyStatus").type(JsonFieldType.STRING)
-            .description("행사 신청 기간의 진행 상황(IN_PROGRESS, UPCOMING, ENDED)"),
-        fieldWithPath("[].remainingDays").type(JsonFieldType.NUMBER)
-            .description("행사 시작일까지 남은 일 수"),
-        fieldWithPath("[].applyRemainingDays").type(JsonFieldType.NUMBER)
-            .description("행사 신청 시작일까지 남은 일 수"),
-        fieldWithPath("[].imageUrl").type(JsonFieldType.STRING)
+        PayloadDocumentation.fieldWithPath("[].imageUrl").type(JsonFieldType.STRING)
             .description("행사 이미지 URL"),
-        fieldWithPath("[].eventMode").type(JsonFieldType.STRING)
+        PayloadDocumentation.fieldWithPath("[].eventMode").type(JsonFieldType.STRING)
             .description("행사 온라인 여부(온라인, 오프라인, 온오프라인)"),
-        fieldWithPath("[].paymentType").type(JsonFieldType.STRING)
+        PayloadDocumentation.fieldWithPath("[].paymentType").type(JsonFieldType.STRING)
             .description("행사 유료 여부(유료, 무료, 유무료)")
     );
 
     final List<EventResponse> eventResponses = List.of(
-        new EventResponse(1L, "인프콘 2023", LocalDateTime.parse("2023-06-03T12:00:00"),
+        new EventResponse(
+            1L,
+            "인프콘 2023",
+            LocalDateTime.parse("2023-06-03T12:00:00"),
             LocalDateTime.parse("2023-09-03T12:00:00"),
-            List.of("백엔드", "프론트엔드", "안드로이드", "IOS", "AI"), "IN_PROGRESS", "ENDED",
+            LocalDateTime.parse("2023-09-01T00:00:00"),
+            LocalDateTime.parse("2023-09-02T23:59:59"),
+            List.of("백엔드", "프론트엔드", "안드로이드", "IOS", "AI"),
             "https://biz.pusan.ac.kr/dext5editordata/2022/08/20220810_160546511_10103.jpg",
-            3, -30, EventMode.ONLINE.getValue(), PaymentType.PAID.getValue()),
-        new EventResponse(5L, "웹 컨퍼런스", LocalDateTime.parse("2023-07-03T12:00:00"),
-            LocalDateTime.parse("2023-08-03T12:00:00"), List.of("백엔드", "프론트엔드"),
-            "IN_PROGRESS", "IN_PROGRESS",
+            EventMode.ONLINE.getValue(),
+            PaymentType.PAID.getValue()
+        ),
+        new EventResponse(
+            5L,
+            "웹 컨퍼런스",
+            LocalDateTime.parse("2023-07-03T12:00:00"),
+            LocalDateTime.parse("2023-08-03T12:00:00"),
+            LocalDateTime.parse("2023-06-23T10:00:00"),
+            LocalDateTime.parse("2023-07-03T12:00:00"),
+            List.of("백엔드", "프론트엔드"),
             "https://biz.pusan.ac.kr/dext5editordata/2022/08/20220810_160546511_10103.jpg",
-            3, 3, EventMode.ONLINE.getValue(), PaymentType.PAID.getValue()),
-        new EventResponse(2L, "AI 컨퍼런스", LocalDateTime.parse("2023-07-22T12:00:00"),
-            LocalDateTime.parse("2023-07-30T12:00:00"), List.of("AI"), "UPCOMING",
-            "IN_PROGRESS",
+            EventMode.ONLINE.getValue(),
+            PaymentType.PAID.getValue()),
+        new EventResponse(2L,
+            "AI 컨퍼런스",
+            LocalDateTime.parse("2023-07-22T12:00:00"),
+            LocalDateTime.parse("2023-07-30T12:00:00"),
+            LocalDateTime.parse("2023-07-01T00:00:00"),
+            LocalDateTime.parse("2023-07-21T23:59:59"),
+            List.of("AI"),
             "https://biz.pusan.ac.kr/dext5editordata/2022/08/20220810_160546511_10103.jpg",
-            3, -18, EventMode.ONLINE.getValue(), PaymentType.PAID.getValue())
+            EventMode.ONLINE.getValue(),
+            PaymentType.PAID.getValue())
     );
 
     Mockito.when(eventService.findEvents(any(EventType.class),
@@ -230,7 +244,7 @@ class EventApiTest extends MockMvcTestHelper {
     Mockito.when(eventService.updateEvent(eq(eventId), any(EventDetailRequest.class), any(), any()))
         .thenReturn(response);
 
-    String contents = objectMapper.writeValueAsString(request);
+    final String contents = objectMapper.writeValueAsString(request);
 
     final RequestPartsSnippet requestPartsSnippet = requestParts(
         partWithName("images").description("이미지들").optional(),
@@ -253,7 +267,8 @@ class EventApiTest extends MockMvcTestHelper {
     );
 
     //when
-    MockMultipartHttpServletRequestBuilder builder = multipart(HttpMethod.PUT, "/events/" + eventId)
+    final MockMultipartHttpServletRequestBuilder builder = multipart(HttpMethod.PUT,
+        "/events/" + eventId)
         .file("images", image1.getBytes())
         .file("images", image2.getBytes())
         .file(new MockMultipartFile("request", "", "application/json", contents.getBytes(
@@ -331,7 +346,7 @@ class EventApiTest extends MockMvcTestHelper {
       Mockito.when(eventService.addEvent(any(EventDetailRequest.class), any(), any()))
           .thenReturn(response);
 
-      String contents = objectMapper.writeValueAsString(request);
+      final String contents = objectMapper.writeValueAsString(request);
 
       final RequestPartsSnippet requestPartsSnippet = requestParts(
           partWithName("images").description("이미지들").optional(),
@@ -354,7 +369,7 @@ class EventApiTest extends MockMvcTestHelper {
       );
 
       //when
-      MockMultipartHttpServletRequestBuilder builder = multipart("/events")
+      final MockMultipartHttpServletRequestBuilder builder = multipart("/events")
           .file("images", image1.getBytes())
           .file("images", image2.getBytes())
           .file(new MockMultipartFile("request", "", "application/json", contents.getBytes(
@@ -399,7 +414,7 @@ class EventApiTest extends MockMvcTestHelper {
           event.getEventPeriod().getApplyStartDate(), event.getEventPeriod().getApplyEndDate(),
           tags, event.getImageUrl(), event.getType(), event.getEventMode(),
           event.getPaymentType(), event.getOrganization());
-      String contents = objectMapper.writeValueAsString(request);
+      final String contents = objectMapper.writeValueAsString(request);
       //when & then
       mockMvc.perform(multipart("/events")
               .file("images", image1.getBytes())
@@ -440,7 +455,7 @@ class EventApiTest extends MockMvcTestHelper {
           event.getEventPeriod().getApplyStartDate(), event.getEventPeriod().getApplyEndDate(),
           tags, event.getImageUrl(), event.getType(), event.getEventMode(),
           event.getPaymentType(), event.getOrganization());
-      String contents = objectMapper.writeValueAsString(request);
+      final String contents = objectMapper.writeValueAsString(request);
       //when & then
       mockMvc.perform(multipart("/events")
               .file("images", image1.getBytes())
@@ -482,7 +497,7 @@ class EventApiTest extends MockMvcTestHelper {
           event.getEventPeriod().getApplyStartDate(), event.getEventPeriod().getApplyEndDate(),
           tags, event.getImageUrl(), event.getType(), event.getEventMode(),
           event.getPaymentType(), event.getOrganization());
-      String contents = objectMapper.writeValueAsString(request);
+      final String contents = objectMapper.writeValueAsString(request);
       //when & then
       mockMvc.perform(multipart("/events")
               .file("images", image1.getBytes())
@@ -517,7 +532,7 @@ class EventApiTest extends MockMvcTestHelper {
 
       final Event event = EventFixture.인프콘_2023();
 
-      Map<String, String> request = new HashMap<>();
+      final Map<String, String> request = new HashMap<>();
       request.put("name", event.getName());
       request.put("location", event.getLocation());
       request.put("informationUrl", event.getInformationUrl());
@@ -531,7 +546,7 @@ class EventApiTest extends MockMvcTestHelper {
       request.put("paymentType", event.getPaymentType().name());
       request.put("organization", event.getOrganization());
 
-      String contents = objectMapper.writeValueAsString(request);
+      final String contents = objectMapper.writeValueAsString(request);
       //when & then
       mockMvc.perform(multipart("/events")
               .file("images", image1.getBytes())
@@ -565,7 +580,7 @@ class EventApiTest extends MockMvcTestHelper {
 
       final Event event = EventFixture.인프콘_2023();
 
-      Map<String, String> request = new HashMap<>();
+      final Map<String, String> request = new HashMap<>();
       request.put("name", event.getName());
       request.put("location", event.getLocation());
       request.put("informationUrl", event.getInformationUrl());
@@ -579,7 +594,7 @@ class EventApiTest extends MockMvcTestHelper {
       request.put("paymentType", event.getPaymentType().name());
       request.put("organization", event.getOrganization());
 
-      String contents = objectMapper.writeValueAsString(request);
+      final String contents = objectMapper.writeValueAsString(request);
       //when & then
       mockMvc.perform(multipart("/events")
               .file("images", image1.getBytes())

--- a/backend/emm-sale/src/documentTest/java/com/emmsale/ScrapApiTest.java
+++ b/backend/emm-sale/src/documentTest/java/com/emmsale/ScrapApiTest.java
@@ -36,40 +36,54 @@ class ScrapApiTest extends MockMvcTestHelper {
   void findAllScraps() throws Exception {
     //given
     final List<EventResponse> expectedScrapResponse = List.of(
-        new EventResponse(1L, "인프콘 2023", LocalDateTime.parse("2023-06-03T12:00:00"),
+        new EventResponse(
+            1L,
+            "인프콘 2023",
+            LocalDateTime.parse("2023-06-03T12:00:00"),
             LocalDateTime.parse("2023-09-03T12:00:00"),
-            List.of("백엔드", "프론트엔드", "안드로이드", "IOS", "AI"), "IN_PROGRESS", "ENDED",
+            LocalDateTime.parse("2023-09-01T00:00:00"),
+            LocalDateTime.parse("2023-09-02T23:59:59"),
+            List.of("백엔드", "프론트엔드", "안드로이드", "IOS", "AI"),
             "https://biz.pusan.ac.kr/dext5editordata/2022/08/20220810_160546511_10103.jpg",
-            3, -30, EventMode.ONLINE.getValue(), PaymentType.PAID.getValue()),
-        new EventResponse(5L, "웹 컨퍼런스", LocalDateTime.parse("2023-07-03T12:00:00"),
-            LocalDateTime.parse("2023-08-03T12:00:00"), List.of("백엔드", "프론트엔드"),
-            "IN_PROGRESS", "IN_PROGRESS",
+            EventMode.ONLINE.getValue(),
+            PaymentType.PAID.getValue()
+        ),
+        new EventResponse(
+            5L,
+            "웹 컨퍼런스",
+            LocalDateTime.parse("2023-07-03T12:00:00"),
+            LocalDateTime.parse("2023-08-03T12:00:00"),
+            LocalDateTime.parse("2023-06-23T10:00:00"),
+            LocalDateTime.parse("2023-07-03T12:00:00"),
+            List.of("백엔드", "프론트엔드"),
             "https://biz.pusan.ac.kr/dext5editordata/2022/08/20220810_160546511_10103.jpg",
-            3, 3, EventMode.ONLINE.getValue(), PaymentType.PAID.getValue()),
-        new EventResponse(2L, "AI 컨퍼런스", LocalDateTime.parse("2023-07-22T12:00:00"),
-            LocalDateTime.parse("2023-07-30T12:00:00"), List.of("AI"), "UPCOMING",
-            "IN_PROGRESS",
+            EventMode.ONLINE.getValue(),
+            PaymentType.PAID.getValue()),
+        new EventResponse(2L,
+            "AI 컨퍼런스",
+            LocalDateTime.parse("2023-07-22T12:00:00"),
+            LocalDateTime.parse("2023-07-30T12:00:00"),
+            LocalDateTime.parse("2023-07-01T00:00:00"),
+            LocalDateTime.parse("2023-07-21T23:59:59"),
+            List.of("AI"),
             "https://biz.pusan.ac.kr/dext5editordata/2022/08/20220810_160546511_10103.jpg",
-            3, -18, EventMode.ONLINE.getValue(), PaymentType.PAID.getValue())
+            EventMode.ONLINE.getValue(),
+            PaymentType.PAID.getValue())
     );
 
     final ResponseFieldsSnippet responseFields = PayloadDocumentation.responseFields(
         PayloadDocumentation.fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("행사 id"),
         PayloadDocumentation.fieldWithPath("[].name").type(JsonFieldType.STRING).description("행사명"),
-        PayloadDocumentation.fieldWithPath("[].startDate").type(JsonFieldType.STRING)
+        PayloadDocumentation.fieldWithPath("[].eventStartDate").type(JsonFieldType.STRING)
             .description("행사 시작일(yyyy:MM:dd:HH:mm:ss)"),
-        PayloadDocumentation.fieldWithPath("[].endDate").type(JsonFieldType.STRING)
+        PayloadDocumentation.fieldWithPath("[].eventEndDate").type(JsonFieldType.STRING)
+            .description("행사 마감일(yyyy:MM:dd:HH:mm:ss)"),
+        PayloadDocumentation.fieldWithPath("[].applyStartDate").type(JsonFieldType.STRING)
+            .description("행사 시작일(yyyy:MM:dd:HH:mm:ss)"),
+        PayloadDocumentation.fieldWithPath("[].applyEndDate").type(JsonFieldType.STRING)
             .description("행사 마감일(yyyy:MM:dd:HH:mm:ss)"),
         PayloadDocumentation.fieldWithPath("[].tags[]").type(JsonFieldType.ARRAY)
             .description("행사 태그 목록"),
-        PayloadDocumentation.fieldWithPath("[].status").type(JsonFieldType.STRING)
-            .description("행사 진행 상황(IN_PROGRESS, UPCOMING, ENDED)"),
-        PayloadDocumentation.fieldWithPath("[].applyStatus").type(JsonFieldType.STRING)
-            .description("행사 신청 기간의 진행 상황(IN_PROGRESS, UPCOMING, ENDED)"),
-        PayloadDocumentation.fieldWithPath("[].remainingDays").type(JsonFieldType.NUMBER)
-            .description("행사 시작일까지 남은 일 수"),
-        PayloadDocumentation.fieldWithPath("[].applyRemainingDays").type(JsonFieldType.NUMBER)
-            .description("행사 신청 시작일까지 남은 일 수"),
         PayloadDocumentation.fieldWithPath("[].imageUrl").type(JsonFieldType.STRING)
             .description("행사 이미지 URL"),
         PayloadDocumentation.fieldWithPath("[].eventMode").type(JsonFieldType.STRING)

--- a/backend/emm-sale/src/main/java/com/emmsale/event/application/EventService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/application/EventService.java
@@ -91,7 +91,7 @@ public class EventService {
     final EnumMap<EventStatus, List<Event>> eventsForEventStatus
         = groupByEventStatus(nowDate, events);
 
-    return filterByStatuses(nowDate, statuses, eventsForEventStatus);
+    return filterByStatuses(statuses, eventsForEventStatus);
   }
 
   private boolean isExistTagNames(final List<String> tagNames) {
@@ -115,7 +115,7 @@ public class EventService {
         return LocalDate.parse(MIN_DATE).atStartOfDay();
       }
       return LocalDate.parse(date).atStartOfDay();
-    } catch (DateTimeParseException exception) {
+    } catch (final DateTimeParseException exception) {
       throw new EventException(EventExceptionType.INVALID_DATE_FORMAT);
     }
   }
@@ -126,7 +126,7 @@ public class EventService {
         return LocalDate.parse(MAX_DATE).atTime(23, 59, 59);
       }
       return LocalDate.parse(date).atTime(23, 59, 59);
-    } catch (DateTimeParseException exception) {
+    } catch (final DateTimeParseException exception) {
       throw new EventException(EventExceptionType.INVALID_DATE_FORMAT);
     }
   }
@@ -149,14 +149,13 @@ public class EventService {
   }
 
   private List<EventResponse> filterByStatuses(
-      final LocalDate today,
       final List<EventStatus> statuses,
       final EnumMap<EventStatus, List<Event>> eventsForEventStatus
   ) {
     if (isExistStatusName(statuses)) {
-      return filterEventResponseByStatuses(today, statuses, eventsForEventStatus);
+      return filterEventResponseByStatuses(statuses, eventsForEventStatus);
     }
-    return EventResponse.mergeEventResponses(today, eventsForEventStatus);
+    return EventResponse.mergeEventResponses(eventsForEventStatus);
   }
 
   private boolean isExistStatusName(final List<EventStatus> statuses) {
@@ -164,15 +163,13 @@ public class EventService {
   }
 
   private List<EventResponse> filterEventResponseByStatuses(
-      final LocalDate today,
       final List<EventStatus> statuses,
       final EnumMap<EventStatus, List<Event>> eventsForEventStatus
   ) {
     return eventsForEventStatus.entrySet()
         .stream()
         .filter(entry -> statuses.contains(entry.getKey()))
-        .map(entry -> EventResponse.makeEventResponsesByStatus(today, entry.getKey(),
-            entry.getValue()))
+        .map(entry -> EventResponse.makeEventResponsesByStatus(entry.getValue()))
         .reduce(new ArrayList<>(), (combinedEvents, eventsToAdd) -> {
           combinedEvents.addAll(eventsToAdd);
           return combinedEvents;

--- a/backend/emm-sale/src/main/java/com/emmsale/scrap/application/ScrapQueryService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/scrap/application/ScrapQueryService.java
@@ -29,6 +29,6 @@ public class ScrapQueryService {
         .stream()
         .map(Scrap::getEvent)
         .collect(groupingBy(event -> event.getEventPeriod().calculateEventStatus(LocalDate.now())));
-    return EventResponse.mergeEventResponses(LocalDate.now(), eventGroupByStatus);
+    return EventResponse.mergeEventResponses(eventGroupByStatus);
   }
 }

--- a/backend/emm-sale/src/test/java/com/emmsale/event/application/EventServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/application/EventServiceTest.java
@@ -71,27 +71,20 @@ import org.springframework.web.multipart.MultipartFile;
 class EventServiceTest extends ServiceIntegrationTestHelper {
 
   private static final EventResponse 인프콘_2023 = new EventResponse(null, "인프콘 2023", null, null,
-      List.of(), "IN_PROGRESS", "ENDED", null, 0, 0, EventMode.OFFLINE.getValue(),
+      null, null, List.of(), null, EventMode.OFFLINE.getValue(),
       PaymentType.PAID.getValue());
-  private static final EventResponse 웹_컨퍼런스 = new EventResponse(null, "웹 컨퍼런스", null, null,
-      List.of(), "IN_PROGRESS", "IN_PROGRESS", null, 0, 0, EventMode.ONLINE.getValue(),
-      PaymentType.PAID.getValue());
-  private static final EventResponse 안드로이드_컨퍼런스 = new EventResponse(null, "안드로이드 컨퍼런스",
-      null, null,
-      List.of(), "ENDED", "ENDED", null, 0, 0, EventMode.ONLINE.getValue(),
-      PaymentType.PAID.getValue());
-  private static final EventResponse AI_컨퍼런스 = new EventResponse(null, "AI 컨퍼런스", null, null,
-      List.of(), "UPCOMING", "IN_PROGRESS", null, 0, 0, EventMode.ONLINE.getValue(),
-      PaymentType.PAID.getValue());
+  private static final EventResponse 웹_컨퍼런스 = new EventResponse(null, "웹 컨퍼런스", null, null, null,
+      null, List.of(), null, EventMode.ONLINE.getValue(), PaymentType.PAID.getValue());
+  private static final EventResponse 안드로이드_컨퍼런스 = new EventResponse(null, "안드로이드 컨퍼런스", null, null,
+      null, null, List.of(), EventMode.ONLINE.getValue(), null, PaymentType.PAID.getValue());
+  private static final EventResponse AI_컨퍼런스 = new EventResponse(null, "AI 컨퍼런스", null, null, null,
+      null, List.of(), null, EventMode.ONLINE.getValue(), PaymentType.PAID.getValue());
   private static final EventResponse 모바일_컨퍼런스 = new EventResponse(null, "모바일 컨퍼런스", null, null,
-      List.of(), "UPCOMING", "UPCOMING", null, 0, 0, EventMode.ONLINE.getValue(),
-      PaymentType.PAID.getValue());
+      null, null, List.of(), null, EventMode.ONLINE.getValue(), PaymentType.PAID.getValue());
   private static final EventResponse AI_아이디어_공모전 = new EventResponse(null, "AI 아이디어 공모전", null,
-      null, List.of(), "ENDED", "ENDED", null, 0, 0, EventMode.ONLINE.getValue(),
-      PaymentType.PAID.getValue());
-  private static final EventResponse 구름톤 = new EventResponse(null, "구름톤", null, null,
-      List.of(), "IN_PROGRESS", "IN_PROGRESS", null, 0, 0, EventMode.ONLINE.getValue(),
-      PaymentType.PAID.getValue());
+      null, null, null, List.of(), null, EventMode.ONLINE.getValue(), PaymentType.PAID.getValue());
+  private static final EventResponse 구름톤 = new EventResponse(null, "구름톤", null, null, null, null,
+      List.of(), null, EventMode.ONLINE.getValue(), PaymentType.PAID.getValue());
 
 
   private static final LocalDate TODAY = LocalDate.of(2023, 7, 21);

--- a/backend/emm-sale/src/test/java/com/emmsale/scrap/application/ScrapQueryServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/scrap/application/ScrapQueryServiceTest.java
@@ -11,7 +11,6 @@ import com.emmsale.member.domain.Member;
 import com.emmsale.member.domain.MemberRepository;
 import com.emmsale.scrap.domain.Scrap;
 import com.emmsale.scrap.domain.ScrapRepository;
-import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -46,19 +45,17 @@ class ScrapQueryServiceTest extends ServiceIntegrationTestHelper {
 
     final List<EventResponse> expected = List.of(
         new EventResponse(event1.getId(), event1.getName(), event1.getEventPeriod().getStartDate(),
-            event1.getEventPeriod().getEndDate(),
-            Collections.emptyList(), "ENDED", "ENDED", event1.getImageUrl(), event1.getEventPeriod()
-            .calculateRemainingDays(LocalDate.now()), event1.getEventPeriod()
-            .calculateApplyRemainingDays(LocalDate.now()), event1
-            .getEventMode().getValue(), event1.getPaymentType().getValue()),
-
+            event1.getEventPeriod().getEndDate(), event1.getEventPeriod().getApplyStartDate(),
+            event1.getEventPeriod().getApplyEndDate(),
+            Collections.emptyList(), event1.getImageUrl(), event1.getEventMode().getValue(),
+            event1.getPaymentType().getValue()),
         new EventResponse(event2.getId(), event2.getName(), event2.getEventPeriod().getStartDate(),
-            event2.getEventPeriod().getEndDate(),
-            Collections.emptyList(), "ENDED", "ENDED", event2.getImageUrl(), event2.getEventPeriod()
-            .calculateRemainingDays(LocalDate.now()), event2.getEventPeriod()
-            .calculateApplyRemainingDays(LocalDate.now()), event2
-            .getEventMode().getValue(), event2.getPaymentType().getValue())
+            event2.getEventPeriod().getEndDate(), event2.getEventPeriod().getApplyStartDate(),
+            event2.getEventPeriod().getApplyEndDate(),
+            Collections.emptyList(), event2.getImageUrl(), event2.getEventMode().getValue(),
+            event2.getPaymentType().getValue())
     );
+
     //then
     assertThat(actual)
         .usingRecursiveComparison()


### PR DESCRIPTION
## #️⃣연관된 이슈
- #650 

close #650 

## 📝작업 내용
행사 조회 api의 행사 신청/시작 상태와 남은 일 수 계산 로직을 제거했습니다.

## 예상 소요 시간 및 실제 소요 시간
2시간 / 2시간
