### PR TITLE
fix: 채팅 날짜 구분이 동일한 버그 수정

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageList/MessageListViewModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageList/MessageListViewModel.kt
@@ -117,7 +117,7 @@ class MessageListViewModel @Inject constructor(
     }
 
     private fun Message.createMessageDateUiState(): MessageDateUiState = MessageDateUiState(
-        date = createdAt.toString(),
+        messageDate = createdAt,
     )
 
     private fun Message.createChatMessageUiState(

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageList/uistate/MessageDateUiState.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageList/uistate/MessageDateUiState.kt
@@ -4,5 +4,5 @@ import java.time.LocalDateTime
 
 class MessageDateUiState(
     override val messageType: MessageType = MessageType.DATE,
-    date: String,
-) : MessageUiState(date, LocalDateTime.now())
+    messageDate: LocalDateTime,
+) : MessageUiState("", messageDate)

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageList/uistate/MessageDateUiState.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageList/uistate/MessageDateUiState.kt
@@ -5,4 +5,4 @@ import java.time.LocalDateTime
 class MessageDateUiState(
     override val messageType: MessageType = MessageType.DATE,
     messageDate: LocalDateTime,
-) : MessageUiState("", messageDate)
+) : MessageUiState(messageDate.toString(), messageDate)


### PR DESCRIPTION
## #️⃣연관된 이슈
>  #667

## 📝작업 내용
> 채팅 날짜 구분이 동일한 버그를 수정했습니다.
확인해보니, LocalDateTime.now()를 전달해주고 있더군요.
메시지를 보낸 날짜로 변경하였습니다.

### 스크린샷 (선택)
<img width="372" alt="스크린샷 2023-09-27 오후 2 51 01" src="https://github.com/woowacourse-teams/2023-emmsale/assets/56534241/40cff9bd-3987-4a4c-bbaa-ba2730b00977">


## 예상 소요 시간 및 실제 소요 시간
> 1시간 / 10분

## 리뷰어 요구사항

따로 문제가 없다면, 마지막으로 approve 하시는 분이 merge 부탁드립니다!