### PR TITLE
fix: 날짜 필터만 설정했을 때 필터 화면을 보여주지 않는 버그 수정

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/competitionList/CompetitionFragment.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/competitionList/CompetitionFragment.kt
@@ -112,14 +112,14 @@ class CompetitionFragment : BaseFragment<FragmentCompetitionBinding>() {
         val endDateString = endDate?.transformToDateString(requireContext(), true) ?: ""
         val durationString = "$startDateString$endDateString"
 
-        if (startDateString != null) {
-            binding.layoutCompetitionFilters.addView(
-                createFilterTag(
-                    title = durationString,
-                    onClick = { viewModel.removeDurationFilteringOption() },
-                ),
-            )
-        }
+        if (startDateString == null) return
+
+        binding.layoutCompetitionFilters.addView(
+            createFilterTag(
+                title = durationString,
+                onClick = { viewModel.removeDurationFilteringOption() },
+            ),
+        )
     }
 
     private fun createFilterTag(title: String, onClick: () -> Unit): FilterTag = filterChipOf {

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/competitionList/uiState/CompetitionSelectedFilteringUiState.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/competitionList/uiState/CompetitionSelectedFilteringUiState.kt
@@ -14,8 +14,12 @@ data class CompetitionSelectedFilteringUiState(
         .map { it.id }
         .toTypedArray()
 
-    val selectedFilterSize: Int =
-        competitionStatusFilteringOptions.size + competitionTagFilteringOptions.size
+    val isShowFilter: Boolean
+        get() {
+            if (selectedStartDate != null) return true
+            if (selectedEndDate != null) return true
+            return selectedStatusFilteringOptionIds.size + selectedTagFilteringOptionIds.size > 0
+        }
 
     fun removeFilteringOptionBy(filterId: Long): CompetitionSelectedFilteringUiState = copy(
         competitionStatusFilteringOptions = competitionStatusFilteringOptions.filterNot { filterOption ->

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/conferenceList/ConferenceFragment.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/conferenceList/ConferenceFragment.kt
@@ -85,7 +85,7 @@ class ConferenceFragment : BaseFragment<FragmentConferenceBinding>() {
         viewModel.selectedFilter.observe(viewLifecycleOwner) { filters ->
             clearFilterViews()
             addFilterViews(filters.tagFilteringOptions + filters.statusFilteringOptions)
-            addDurationFilter(filters.startDateFilteringOption, filters.endDateFilteringOption)
+            addDurationFilter(filters.selectedStartDate, filters.selectedEndDate)
         }
     }
 
@@ -112,14 +112,14 @@ class ConferenceFragment : BaseFragment<FragmentConferenceBinding>() {
         val endDateString = endDate?.transformToDateString(requireContext(), true) ?: ""
         val durationString = "$startDateString$endDateString"
 
-        if (startDateString != null) {
-            binding.layoutConferenceFilters.addView(
-                createFilterTag(
-                    title = durationString,
-                    onClick = { viewModel.removeDurationFilteringOption() },
-                ),
-            )
-        }
+        if (startDateString == null) return
+
+        binding.layoutConferenceFilters.addView(
+            createFilterTag(
+                title = durationString,
+                onClick = { viewModel.removeDurationFilteringOption() },
+            ),
+        )
     }
 
     private fun createFilterTag(title: String, onClick: () -> Unit): FilterTag = filterChipOf {
@@ -141,8 +141,8 @@ class ConferenceFragment : BaseFragment<FragmentConferenceBinding>() {
             context = requireContext(),
             selectedStatusIds = selectedFilter.selectedStatusFilteringOptionIds,
             selectedTagIds = selectedFilter.selectedTagFilteringOptionIds,
-            selectedStartDate = selectedFilter.startDateFilteringOption?.date,
-            selectedEndDate = selectedFilter.endDateFilteringOption?.date,
+            selectedStartDate = selectedFilter.selectedStartDate?.date,
+            selectedEndDate = selectedFilter.selectedEndDate?.date,
         )
         filterActivityLauncher.launch(filterActivityIntent)
     }

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/conferenceList/ConferenceViewModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/conferenceList/ConferenceViewModel.kt
@@ -118,10 +118,10 @@ class ConferenceViewModel @Inject constructor(
                 tagFilteringOptions = tagFilteringOptions.map(
                     ConferenceSelectedFilteringOptionUiState::from,
                 ),
-                startDateFilteringOption = startDate?.let(
+                selectedStartDate = startDate?.let(
                     ConferenceSelectedFilteringDateOptionUiState::from,
                 ),
-                endDateFilteringOption = endDate?.let(ConferenceSelectedFilteringDateOptionUiState::from),
+                selectedEndDate = endDate?.let(ConferenceSelectedFilteringDateOptionUiState::from),
             ),
         )
     }
@@ -158,8 +158,8 @@ class ConferenceViewModel @Inject constructor(
             fetchFilteredConferences(
                 selectedStatusFilteringOptionIds,
                 selectedTagFilteringOptionIds,
-                startDateFilteringOption?.date,
-                endDateFilteringOption?.date,
+                selectedStartDate?.date,
+                selectedEndDate?.date,
             )
         }
     }

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/conferenceList/uiState/ConferenceSelectedFilteringUiState.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/conferenceList/uiState/ConferenceSelectedFilteringUiState.kt
@@ -3,8 +3,8 @@ package com.emmsale.presentation.ui.conferenceList.uiState
 data class ConferenceSelectedFilteringUiState(
     val statusFilteringOptions: List<ConferenceSelectedFilteringOptionUiState> = emptyList(),
     val tagFilteringOptions: List<ConferenceSelectedFilteringOptionUiState> = emptyList(),
-    val startDateFilteringOption: ConferenceSelectedFilteringDateOptionUiState? = null,
-    val endDateFilteringOption: ConferenceSelectedFilteringDateOptionUiState? = null,
+    val selectedStartDate: ConferenceSelectedFilteringDateOptionUiState? = null,
+    val selectedEndDate: ConferenceSelectedFilteringDateOptionUiState? = null,
 ) {
     val selectedStatusFilteringOptionIds: Array<Long> = statusFilteringOptions
         .map { it.id }
@@ -14,7 +14,12 @@ data class ConferenceSelectedFilteringUiState(
         .map { it.id }
         .toTypedArray()
 
-    val selectedFilterSize = statusFilteringOptions.size + tagFilteringOptions.size
+    val isShowFilter: Boolean
+        get() {
+            if (selectedStartDate != null) return true
+            if (selectedEndDate != null) return true
+            return selectedStatusFilteringOptionIds.size + selectedTagFilteringOptionIds.size > 0
+        }
 
     fun removeFilteringOptionBy(filterId: Long): ConferenceSelectedFilteringUiState = copy(
         statusFilteringOptions = statusFilteringOptions.filterNot { filterOption ->
@@ -26,7 +31,7 @@ data class ConferenceSelectedFilteringUiState(
     )
 
     fun clearSelectedDate(): ConferenceSelectedFilteringUiState = copy(
-        startDateFilteringOption = null,
-        endDateFilteringOption = null,
+        selectedStartDate = null,
+        selectedEndDate = null,
     )
 }

--- a/android/2023-emmsale/app/src/main/res/layout/fragment_competition.xml
+++ b/android/2023-emmsale/app/src/main/res/layout/fragment_competition.xml
@@ -88,10 +88,10 @@
             android:overScrollMode="never"
             android:paddingHorizontal="17dp"
             android:scrollbars="none"
-            android:visibility="@{viewModel.selectedFilter.selectedFilterSize > 0 ? View.VISIBLE : View.GONE}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/btn_event_filter">
+            app:layout_constraintTop_toBottomOf="@+id/btn_event_filter"
+            app:visible="@{viewModel.selectedFilter.isShowFilter}">
 
             <LinearLayout
                 android:id="@+id/layout_competition_filters"

--- a/android/2023-emmsale/app/src/main/res/layout/fragment_conference.xml
+++ b/android/2023-emmsale/app/src/main/res/layout/fragment_conference.xml
@@ -88,10 +88,10 @@
             android:overScrollMode="never"
             android:paddingHorizontal="17dp"
             android:scrollbars="none"
-            android:visibility="@{viewModel.selectedFilter.selectedFilterSize > 0 ? View.VISIBLE : View.GONE}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/btn_event_filter">
+            app:layout_constraintTop_toBottomOf="@+id/btn_event_filter"
+            app:visible="@{viewModel.selectedFilter.isShowFilter}">
 
             <LinearLayout
                 android:id="@+id/layout_conference_filters"


### PR DESCRIPTION
## #️⃣연관된 이슈
>  #627

## 📝작업 내용
> 날짜 필터만 설정했을 때 필터 화면이 보여지지 않는 버그를 수정했습니다.
기존 UI 로직에서, 필터 화면을 보여주는 기준에 날짜 필터 선택 여부는 고려되지 않고 있었습니다.

### 스크린샷 (선택)
<img width="527" alt="스크린샷 2023-09-27 오후 3 42 42" src="https://github.com/woowacourse-teams/2023-emmsale/assets/56534241/e961ec89-1603-4e2e-9729-8d3fc7ae0dfc">

## 예상 소요 시간 및 실제 소요 시간
> 1일 / 20분

## 리뷰어 요구사항
간단한 버그 수정이라 바로 merge하겠습니다.