### PR TITLE
Feature/#670-피드_이미지_정렬_기능_추가

### DIFF
--- a/backend/emm-sale/src/main/java/com/emmsale/feed/application/FeedQueryService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/feed/application/FeedQueryService.java
@@ -18,6 +18,7 @@ import com.emmsale.image.domain.Image;
 import com.emmsale.image.domain.repository.ImageRepository;
 import com.emmsale.member.domain.Member;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -64,7 +65,7 @@ public class FeedQueryService {
   }
 
   private Map<Long, List<Image>> getFeedImagesMap(final List<Long> feedIds) {
-    return imageRepository.findAllByFeedIdIn(feedIds).stream()
+    final Map<Long, List<Image>> feedImagesMap = imageRepository.findAllByFeedIdIn(feedIds).stream()
         .collect(Collectors.groupingBy(
             Image::getContentId,
             Collectors.mapping(
@@ -72,6 +73,10 @@ public class FeedQueryService {
                 Collectors.toList()
             )
         ));
+
+    feedImagesMap.forEach((feedId, images) -> images.sort(Comparator.comparing(Image::getOrder)));
+
+    return feedImagesMap;
   }
 
   private Map<Long, Long> getFeedIdCommentCountMap(final List<Long> feedIds) {
@@ -104,6 +109,7 @@ public class FeedQueryService {
     final Feed feed = feedRepository.findById(id)
         .orElseThrow(() -> new FeedException(FeedExceptionType.NOT_FOUND_FEED));
     final List<Image> images = imageRepository.findAllByFeedId(feed.getId());
+    images.sort(Comparator.comparing(Image::getOrder));
 
     validateBlockedMemberFeed(member, feed);
     validateDeletedFeed(feed);

--- a/backend/emm-sale/src/test/java/com/emmsale/feed/application/FeedQueryServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/feed/application/FeedQueryServiceTest.java
@@ -234,19 +234,23 @@ class FeedQueryServiceTest extends ServiceIntegrationTestHelper {
   @DisplayName("피드 이미지 조회 테스트")
   class FeedQueryWithImage {
 
+    private Image image1;
+    private Image image2;
+    private Image image3;
     private List<Image> images;
 
     @BeforeEach
     void setUp() {
-      images = imageRepository.saveAll(List.of(
-              new Image("image-uuid", ImageType.FEED, feed1.getId(), 1, LocalDateTime.now()),
-              new Image("image-uuid", ImageType.FEED, feed1.getId(), 2, LocalDateTime.now())
-          )
-      );
+      image1 = new Image("image-uuid1", ImageType.FEED, feed1.getId(), 1, LocalDateTime.now());
+      image2 = new Image("image-uuid2", ImageType.FEED, feed1.getId(), 2, LocalDateTime.now());
+      image3 = new Image("image-uuid3", ImageType.FEED, feed1.getId(), 3, LocalDateTime.now());
+      images = List.of(image1, image2, image3);
+
+      imageRepository.saveAll(List.of(image2, image1, image3));
     }
 
     @Test
-    @DisplayName("피드에 이미지가 있을 경우 피드 목록에서 이미지 리스트를 함께 반환한다.")
+    @DisplayName("피드에 이미지가 있을 경우 피드 목록에서 이미지 리스트를 order순으로 정렬하여 함께 반환한다.")
     void findAllFeedsWithImages() {
       //given
       final Long eventId = event.getId();
@@ -268,7 +272,7 @@ class FeedQueryServiceTest extends ServiceIntegrationTestHelper {
     }
 
     @Test
-    @DisplayName("피드에 이미지가 있을 경우 피드 목록에서 이미지 리스트를 함께 반환한다.")
+    @DisplayName("피드에 이미지가 있을 경우 피드 목록에서 이미지 리스트를 order순으로 정렬하여 함께 반환한다.")
     void findDetailFeedWithImages() {
       //given
       final FeedDetailResponse expect = FeedDetailResponse.from(feed1, images);


### PR DESCRIPTION
## #️⃣연관된 이슈
- #670 

close #670 

## 📝작업 내용
예전에 피드를 구현할 때 피드 이미지를 order 순으로 정렬하는 로직을 빠뜨려 추가했습니다.

## 예상 소요 시간 및 실제 소요 시간
2시간 / 2시간
