### PR TITLE
Feature/#665 사용자 프로필 이미지 업데이트

### DIFF
--- a/backend/emm-sale/src/documentTest/asciidoc/index.adoc
+++ b/backend/emm-sale/src/documentTest/asciidoc/index.adoc
@@ -178,6 +178,18 @@ include::{snippets}/delete-interest-tag/http-response.adoc[]
 .HTTP response 설명
 include::{snippets}/delete-interest-tag/response-fields.adoc[]
 
+=== `PATCH` : 사용자의 프로필을 변경한다.
+
+.HTTP request
+```http
+POST /members/2/profile HTTP/1.1
+Content-Type: multipart/form-data; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Host: localhost:8080
+```
+
+.HTTP response
+include::{snippets}/update-profile/http-response.adoc[]
+
 == Event
 
 === `GET` : 행사 상세정보 조회

--- a/backend/emm-sale/src/main/java/com/emmsale/image/application/S3Client.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/image/application/S3Client.java
@@ -19,24 +19,26 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
+//얘 @Component로 바꾸는 거 어떤가요? @Service보단 @Component가 더 적절한 것 같아요.
 @RequiredArgsConstructor
 public class S3Client {
 
   private static final String EXTENSION_DELIMITER = ".";
   private static final List<String> ALLOWED_FILE_EXTENSIONS = List.of(".jpg", ".png", ".jpeg");
   private static final int MIN_EXTENSION_SEPARATOR_INDEX = 0;
-  
+  private static final String URL_DELIMITER = "/";
+
   @Value("${cloud.aws.s3.bucket}")
   private String bucket;
-  
+
   private final AmazonS3 amazonS3;
-  
+
   public List<String> uploadImages(final List<MultipartFile> multipartFiles) {
     return multipartFiles.stream().map(this::uploadImage)
         .collect(Collectors.toList());
   }
 
-  private String uploadImage(final MultipartFile file) {
+  public String uploadImage(final MultipartFile file) {
     final String fileExtension = extractFileExtension(file);
     final String newFileName = UUID.randomUUID().toString().concat(fileExtension);
     final ObjectMetadata objectMetadata = configureObjectMetadata(file);
@@ -79,5 +81,9 @@ public class S3Client {
     } catch (SdkClientException exception) {
       throw new ImageException(ImageExceptionType.FAIL_S3_DELETE_IMAGE);
     }
+  }
+
+  public String convertImageUrl(final String imageName) {
+    return String.join(URL_DELIMITER, bucket, imageName);
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/image/application/S3Client.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/image/application/S3Client.java
@@ -14,11 +14,10 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
-@Service
-//얘 @Component로 바꾸는 거 어떤가요? @Service보단 @Component가 더 적절한 것 같아요.
+@Component
 public class S3Client {
 
   private static final String EXTENSION_DELIMITER = ".";

--- a/backend/emm-sale/src/main/java/com/emmsale/image/application/S3Client.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/image/application/S3Client.java
@@ -13,14 +13,12 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
 //얘 @Component로 바꾸는 거 어떤가요? @Service보단 @Component가 더 적절한 것 같아요.
-@RequiredArgsConstructor
 public class S3Client {
 
   private static final String EXTENSION_DELIMITER = ".";
@@ -28,10 +26,13 @@ public class S3Client {
   private static final int MIN_EXTENSION_SEPARATOR_INDEX = 0;
   private static final String URL_DELIMITER = "/";
 
-  @Value("${cloud.aws.s3.bucket}")
-  private String bucket;
-
+  private final String bucket;
   private final AmazonS3 amazonS3;
+
+  public S3Client(@Value("${cloud.aws.s3.bucket}") final String bucket, final AmazonS3 amazonS3) {
+    this.bucket = bucket;
+    this.amazonS3 = amazonS3;
+  }
 
   public List<String> uploadImages(final List<MultipartFile> multipartFiles) {
     return multipartFiles.stream().map(this::uploadImage)
@@ -85,5 +86,9 @@ public class S3Client {
 
   public String convertImageUrl(final String imageName) {
     return String.join(URL_DELIMITER, bucket, imageName);
+  }
+
+  public String convertImageName(final String imageUrl) {
+    return imageUrl.split(bucket + URL_DELIMITER, 2)[1];
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/member/api/MemberApi.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/api/MemberApi.java
@@ -17,12 +17,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -94,5 +96,15 @@ public class MemberApi {
   ) {
     memberUpdateService.deleteMember(member, memberId);
     return ResponseEntity.noContent().build();
+  }
+
+  @PatchMapping("/members/{memberId}/profile")
+  public ResponseEntity<String> updateProfile(
+      @PathVariable final Long memberId,
+      final MultipartFile image,
+      final Member member
+  ) {
+    final String imageUrl = memberUpdateService.updateMemberProfile(image, memberId, member);
+    return ResponseEntity.ok(imageUrl);
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/member/application/MemberUpdateService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/application/MemberUpdateService.java
@@ -9,6 +9,7 @@ import com.emmsale.member.exception.MemberExceptionType;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional
@@ -42,5 +43,11 @@ public class MemberUpdateService {
     }
 
     memberRepository.deleteById(memberId);
+  }
+
+  public String updateMemberProfile(final MultipartFile image, final Long memberId,
+      final Member member) {
+
+    return null;
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/member/application/MemberUpdateService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/application/MemberUpdateService.java
@@ -53,6 +53,10 @@ public class MemberUpdateService {
       final Long memberId,
       final Member member
   ) {
+    if (member.isNotMe(memberId)) {
+      throw new MemberException(MemberExceptionType.FORBIDDEN_UPDATE_PROFILE_IMAGE);
+    }
+
     if (member.isNotGithubProfile()) {
       final String imageName = s3Client.convertImageName(member.getImageUrl());
       s3Client.deleteImages(List.of(imageName));

--- a/backend/emm-sale/src/main/java/com/emmsale/member/domain/Member.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/domain/Member.java
@@ -18,6 +18,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 
+  private static final String GITHUB_PROFILE_DOMAIN = "https://avatars.githubusercontent.com";
   private static final int MAX_DESCRIPTION_LENGTH = 100;
   private static final String DEFAULT_DESCRIPTION = "";
 
@@ -73,6 +74,10 @@ public class Member extends BaseEntity {
     this.description = description;
   }
 
+  public void updateProfile(final String imageUrl) {
+    this.imageUrl = imageUrl;
+  }
+
   private void validateDescriptionNull(final String description) {
     if (description == null) {
       throw new MemberException(MemberExceptionType.NULL_DESCRIPTION);
@@ -97,13 +102,16 @@ public class Member extends BaseEntity {
     return isNotMe(member.getId());
   }
 
-
   public boolean isNotMe(final Long id) {
     return !this.id.equals(id);
   }
 
   public boolean isOnboarded() {
     return name != null;
+  }
+
+  public boolean isNotGithubProfile() {
+    return !imageUrl.contains(GITHUB_PROFILE_DOMAIN);
   }
 
   public Optional<String> getOptionalOpenProfileUrl() {

--- a/backend/emm-sale/src/main/java/com/emmsale/member/domain/Member.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/domain/Member.java
@@ -38,7 +38,6 @@ public class Member extends BaseEntity {
   @Column(nullable = false)
   private String githubUsername;
 
-
   public Member(final Long id, final Long githubId, final String imageUrl, final String name,
       final String githubUsername) {
     this.id = id;
@@ -111,7 +110,7 @@ public class Member extends BaseEntity {
   }
 
   public boolean isNotGithubProfile() {
-    return !imageUrl.contains(GITHUB_PROFILE_DOMAIN);
+    return !imageUrl.startsWith(GITHUB_PROFILE_DOMAIN);
   }
 
   public Optional<String> getOptionalOpenProfileUrl() {

--- a/backend/emm-sale/src/main/java/com/emmsale/member/exception/MemberExceptionType.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/exception/MemberExceptionType.java
@@ -57,6 +57,11 @@ public enum MemberExceptionType implements BaseExceptionType {
   NOT_MATCHING_TOKEN_AND_LOGIN_MEMBER(
       HttpStatus.UNAUTHORIZED,
       "사용자가 일치하지 않습니다."
+  ),
+
+  FORBIDDEN_UPDATE_PROFILE_IMAGE(
+      HttpStatus.FORBIDDEN,
+      "해당하는 멤버의 프로필을 바꿀 권한이 없습니다."
   );
 
   private final HttpStatus httpStatus;

--- a/backend/emm-sale/src/test/java/com/emmsale/helper/ServiceIntegrationTestHelper.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/helper/ServiceIntegrationTestHelper.java
@@ -1,6 +1,7 @@
 package com.emmsale.helper;
 
 import com.emmsale.image.application.ImageCommandService;
+import com.emmsale.image.application.S3Client;
 import com.emmsale.login.utils.GithubClient;
 import com.emmsale.notification.application.FirebaseCloudMessageClient;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,4 +19,6 @@ public abstract class ServiceIntegrationTestHelper {
   protected FirebaseCloudMessageClient firebaseCloudMessageClient;
   @MockBean
   protected ImageCommandService imageCommandService;
+  @MockBean
+  protected S3Client s3Client;
 }

--- a/backend/emm-sale/src/test/java/com/emmsale/image/application/S3ClientTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/image/application/S3ClientTest.java
@@ -9,7 +9,6 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectResult;
-import com.emmsale.helper.ServiceIntegrationTestHelper;
 import com.emmsale.image.exception.ImageException;
 import com.emmsale.image.exception.ImageExceptionType;
 import java.util.List;
@@ -24,17 +23,17 @@ import org.mockito.BDDMockito;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
-class S3ClientTest extends ServiceIntegrationTestHelper {
-  
+class S3ClientTest {
+
   private S3Client s3Client;
   private AmazonS3 mockingAmazonS3;
-  
+
   @BeforeEach
   void setUp() {
     mockingAmazonS3 = mock(AmazonS3.class);
     s3Client = new S3Client(mockingAmazonS3);
   }
-  
+
   @Test
   @DisplayName("uploadImages(): 올바른 확장자를 갖는 파일을 입력받으면 정상적으로 파일을 S3에 업로드한다.")
   void uploadImages_success() {
@@ -45,16 +44,16 @@ class S3ClientTest extends ServiceIntegrationTestHelper {
         new MockMultipartFile("test", "test.jpeg", "", new byte[]{}));
     BDDMockito.given(mockingAmazonS3.putObject(any(PutObjectRequest.class)))
         .willReturn(new PutObjectResult());
-    
+
     //when
     s3Client.uploadImages(files);
-    
+
     //then
     verify(mockingAmazonS3, times(3))
         .putObject(any(PutObjectRequest.class));
-    
+
   }
-  
+
   @ParameterizedTest
   @ValueSource(strings = {"test.txt", "test"})
   @DisplayName("uploadImages(): 지원하지 않는 확장자를 갖는 파일을 입력받으면 예외를 반환한다.")
@@ -62,28 +61,27 @@ class S3ClientTest extends ServiceIntegrationTestHelper {
     //given
     final List<MultipartFile> files = List.of(
         new MockMultipartFile("test", fileName, "", new byte[]{}));
-    
+
     //when
     final ThrowingCallable actual = () -> s3Client.uploadImages(files);
-    
+
     //then
     Assertions.assertThatThrownBy(actual)
         .isInstanceOf(ImageException.class)
         .hasMessage(ImageExceptionType.INVALID_FILE_FORMAT.errorMessage());
   }
-  
+
   @Test
   @DisplayName("deleteImages(): 올바른 확장자를 갖는 파일을 입력받으면 정상적으로 파일을 S3에 업로드한다.")
   void deleteImages_success() {
     //given
     final List<String> fileNames = List.of("test1", "test2", "test3");
-    
+
     //when
     s3Client.deleteImages(fileNames);
-    
+
     //then
     verify(mockingAmazonS3, times(3))
         .deleteObject(any(DeleteObjectRequest.class));
-    
   }
 }

--- a/backend/emm-sale/src/test/java/com/emmsale/image/application/S3ClientTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/image/application/S3ClientTest.java
@@ -1,5 +1,6 @@
 package com.emmsale.image.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -25,13 +26,15 @@ import org.springframework.web.multipart.MultipartFile;
 
 class S3ClientTest {
 
+  private static final String TEST_BUCKET = "Test";
+
   private S3Client s3Client;
   private AmazonS3 mockingAmazonS3;
 
   @BeforeEach
   void setUp() {
     mockingAmazonS3 = mock(AmazonS3.class);
-    s3Client = new S3Client(mockingAmazonS3);
+    s3Client = new S3Client(TEST_BUCKET, mockingAmazonS3);
   }
 
   @Test
@@ -83,5 +86,29 @@ class S3ClientTest {
     //then
     verify(mockingAmazonS3, times(3))
         .deleteObject(any(DeleteObjectRequest.class));
+  }
+
+  @Test
+  @DisplayName("convertImageUrl(): 이미지 이름을 imageUrl로 바꾼다.")
+  void convertImageUrl() {
+    final String imageName = "image.png";
+    final String expected = "Test/image.png";
+
+    final String actual = s3Client.convertImageUrl(imageName);
+
+    assertThat(actual)
+        .isEqualTo(expected);
+  }
+
+  @Test
+  @DisplayName("convertImageName(): 이미지 이름을 imageName로 바꾼다.")
+  void convertImageName() {
+    final String imageUrl = "Test/image.png";
+    final String expected = "image.png";
+
+    final String actual = s3Client.convertImageName(imageUrl);
+
+    assertThat(actual)
+        .isEqualTo(expected);
   }
 }

--- a/backend/emm-sale/src/test/java/com/emmsale/member/MemberFixture.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/member/MemberFixture.java
@@ -7,7 +7,7 @@ public class MemberFixture {
   public static Member memberFixture() {
     final Member member = new Member(
         1234L,
-        "https://image-url.com",
+        "https://avatars.githubusercontent.com/0/4",
         "아마란스"
     );
     member.updateName("우르");

--- a/backend/emm-sale/src/test/java/com/emmsale/member/application/MemberUpdateServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/member/application/MemberUpdateServiceTest.java
@@ -1,6 +1,7 @@
 package com.emmsale.member.application;
 
 import static com.emmsale.member.MemberFixture.memberFixture;
+import static com.emmsale.member.exception.MemberExceptionType.FORBIDDEN_UPDATE_PROFILE_IMAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -208,6 +209,21 @@ class MemberUpdateServiceTest extends ServiceIntegrationTestHelper {
           () -> verify(s3Client, times(1))
               .deleteImages(anyList())
       );
+    }
+
+    @Test
+    @DisplayName("member와 memberId가 다른 경우 Exception을 throw한다.")
+    void validateMemberIsNotMe() {
+      //given
+      final Member member = memberRepository.save(memberFixture());
+
+      //when && then
+      final ThrowingCallable testTarget = () ->
+          memberUpdateService.updateMemberProfile(image, member.getId() + 1, member);
+
+      assertThatThrownBy(testTarget)
+          .isInstanceOf(MemberException.class)
+          .hasMessage(FORBIDDEN_UPDATE_PROFILE_IMAGE.errorMessage());
     }
   }
 }

--- a/backend/emm-sale/src/test/java/com/emmsale/member/application/MemberUpdateServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/member/application/MemberUpdateServiceTest.java
@@ -1,10 +1,16 @@
 package com.emmsale.member.application;
 
+import static com.emmsale.member.MemberFixture.memberFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.emmsale.helper.ServiceIntegrationTestHelper;
-import com.emmsale.member.MemberFixture;
 import com.emmsale.member.application.dto.DescriptionRequest;
 import com.emmsale.member.application.dto.OpenProfileUrlRequest;
 import com.emmsale.member.domain.Member;
@@ -12,13 +18,18 @@ import com.emmsale.member.domain.MemberRepository;
 import com.emmsale.member.exception.MemberException;
 import com.emmsale.member.exception.MemberExceptionType;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
 
 class MemberUpdateServiceTest extends ServiceIntegrationTestHelper {
 
@@ -31,7 +42,7 @@ class MemberUpdateServiceTest extends ServiceIntegrationTestHelper {
   @DisplayName("오픈 프로필 URL을 업데이트한다.")
   void updateOpenProfileUrlTest() {
     // given
-    final Member member = memberRepository.save(MemberFixture.memberFixture());
+    final Member member = memberRepository.save(memberFixture());
 
     final String expectOpenProfileUrl = "https://open.kakao.com/new/profile/url";
     final OpenProfileUrlRequest request = new OpenProfileUrlRequest(expectOpenProfileUrl);
@@ -54,7 +65,7 @@ class MemberUpdateServiceTest extends ServiceIntegrationTestHelper {
     @DisplayName("정상적으로 업데이트된다.")
     void updateDescription_success(final String inputDescription) {
       // given
-      final Member member = memberRepository.save(MemberFixture.memberFixture());
+      final Member member = memberRepository.save(memberFixture());
 
       final String expectDescription = inputDescription;
       final DescriptionRequest request = new DescriptionRequest(expectDescription);
@@ -72,7 +83,7 @@ class MemberUpdateServiceTest extends ServiceIntegrationTestHelper {
     @DisplayName("한줄 자기소개가 100자를 초과하면 예외를 반환한다.")
     void updateDescription_fail() {
       // given
-      final Member member = memberRepository.save(MemberFixture.memberFixture());
+      final Member member = memberRepository.save(memberFixture());
 
       final String invalidDescription = "안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요!";
       final DescriptionRequest request = new DescriptionRequest(invalidDescription);
@@ -92,7 +103,7 @@ class MemberUpdateServiceTest extends ServiceIntegrationTestHelper {
     @DisplayName("한줄 자기소개에 공백만 들어오면 빈 문자열로 업데이트한다.")
     void updateDescription_trim(final String inputDescription) {
       // given
-      final Member member = memberRepository.save(MemberFixture.memberFixture());
+      final Member member = memberRepository.save(memberFixture());
 
       final String expectDescription = "";
       final DescriptionRequest request = new DescriptionRequest(inputDescription);
@@ -137,6 +148,66 @@ class MemberUpdateServiceTest extends ServiceIntegrationTestHelper {
       assertThatThrownBy(() -> memberUpdateService.deleteMember(member, otherMemberId))
           .isInstanceOf(MemberException.class)
           .hasMessage(MemberExceptionType.FORBIDDEN_DELETE_MEMBER.errorMessage());
+    }
+  }
+
+  @Nested
+  @DisplayName("member의 프로필 이미지가 업데이트 되는 경우, 기존 이미지 값을 지우고 새 이미지 값을 받는다.")
+  class UpdateProfile {
+
+    private final String imageName = "imageName";
+    private final MultipartFile image = Mockito.mock(MultipartFile.class);
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @BeforeEach
+    void setUp() {
+      ReflectionTestUtils.setField(s3Client, "bucket", bucket);
+      when(s3Client.uploadImage(image)).thenReturn(imageName);
+      when(s3Client.convertImageUrl(anyString())).thenCallRealMethod();
+      when(s3Client.convertImageName(anyString())).thenCallRealMethod();
+    }
+
+    @Test
+    @DisplayName("기존 이미지는 깃허브 url인 경우 새로운 이미지를 s3 추가한다.")
+    void pastGithubUrl() {
+      //given
+      final Member fixture = memberFixture();
+      final Member member = memberRepository.save(fixture);
+
+      //when
+      memberUpdateService.updateMemberProfile(image, member.getId(), member);
+
+      //then
+      assertAll(
+          () -> assertThat(member.getImageUrl())
+              .isEqualTo(s3Client.convertImageUrl(imageName)),
+          () -> verify(s3Client, times(1))
+              .uploadImage(image)
+      );
+    }
+
+    @Test
+    @DisplayName("기존 이미지가 s3에 저장된 이미지인 경우, 기존 이미지를 지우고, 새로운 이미지를 추가한다.")
+    void pastCustomImage() {
+      //given
+      final Member fixture = memberFixture();
+      fixture.updateProfile(s3Client.convertImageUrl("already"));
+      final Member member = memberRepository.save(fixture);
+
+      //when
+      memberUpdateService.updateMemberProfile(image, member.getId(), member);
+
+      //then
+      assertAll(
+          () -> assertThat(member.getImageUrl())
+              .isEqualTo(s3Client.convertImageUrl(imageName)),
+          () -> verify(s3Client, times(1))
+              .uploadImage(image),
+          () -> verify(s3Client, times(1))
+              .deleteImages(anyList())
+      );
     }
   }
 }

--- a/backend/emm-sale/src/test/java/com/emmsale/member/domain/MemberTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/member/domain/MemberTest.java
@@ -78,7 +78,6 @@ class MemberTest {
     @Test
     void falseCase() {
       final Member member = MemberFixture.memberFixture();
-      member.updateProfile("https://avatars.githubusercontent.com/o/v4");
 
       assertFalse(member.isNotGithubProfile());
     }
@@ -86,6 +85,7 @@ class MemberTest {
     @Test
     void trueCase() {
       final Member member = MemberFixture.memberFixture();
+      member.updateProfile("custom profile");
 
       assertTrue(member.isNotGithubProfile());
     }

--- a/backend/emm-sale/src/test/java/com/emmsale/member/domain/MemberTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/member/domain/MemberTest.java
@@ -1,11 +1,13 @@
 package com.emmsale.member.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.emmsale.member.MemberFixture;
 import com.emmsale.member.exception.MemberException;
 import com.emmsale.member.exception.MemberExceptionType;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -32,7 +34,7 @@ class MemberTest {
       String actual = member.getDescription();
 
       // then
-      Assertions.assertThat(actual).isEqualTo(inputDescription);
+      assertThat(actual).isEqualTo(inputDescription);
     }
 
     @Test
@@ -58,14 +60,35 @@ class MemberTest {
     @DisplayName("한줄 자기소개에 공백만 들어오면 빈 문자열로 업데이트한다.")
     void updateDescription_trim(final String inputDescription) {
       // given
-      Member member = MemberFixture.memberFixture();
+      final Member member = MemberFixture.memberFixture();
 
       //when
       member.updateDescription(inputDescription);
-      String actual = member.getDescription();
+      final String actual = member.getDescription();
 
       // then
-      Assertions.assertThat(actual).isEmpty();
+      assertThat(actual).isEmpty();
     }
   }
+
+  @Nested
+  @DisplayName("멤버가 자신의 프로필이미지가 github인지 판단한다.")
+  class IsNotGithubProfile {
+
+    @Test
+    void falseCase() {
+      final Member member = MemberFixture.memberFixture();
+      member.updateProfile("https://avatars.githubusercontent.com/o/v4");
+
+      assertFalse(member.isNotGithubProfile());
+    }
+
+    @Test
+    void trueCase() {
+      final Member member = MemberFixture.memberFixture();
+
+      assertTrue(member.isNotGithubProfile());
+    }
+  }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- #665 

## 📝작업 내용
- 사용자 프로필 이미지 업데이트 하는 기능 구현

## 예상 소요 시간 및 실제 소요 시간
- 2시간 / 5시간

## 💬리뷰 요구사항(선택)
- S3Clinet의 bucket관련해서 테스트 짜는 부분이 좀 힘들었어요. 구현은 했는데, 해당 방법에 대해서 괜찮은지 한 번 봐주시면 좋을 것 같아요.