### PR TITLE
feat : 낮은 버젼에서도 이미지를 올릴 수 있도록 구현

### DIFF
--- a/android/2023-emmsale/app/src/main/AndroidManifest.xml
+++ b/android/2023-emmsale/app/src/main/AndroidManifest.xml
@@ -150,20 +150,6 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
-
-        <!--suppress AndroidDomInspection -->
-        <service
-            android:name="com.google.android.gms.metadata.ModuleDependencies"
-            android:enabled="false"
-            android:exported="false"
-            tools:ignore="MissingClass">
-            <intent-filter>
-                <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
-            </intent-filter>
-            <meta-data
-                android:name="photopicker_activity:0:required"
-                android:value="" />
-        </service>
     </application>
 
 </manifest>

--- a/android/2023-emmsale/app/src/main/AndroidManifest.xml
+++ b/android/2023-emmsale/app/src/main/AndroidManifest.xml
@@ -5,7 +5,13 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <!--Image Permission-->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+
     <application
+        android:requestLegacyExternalStorage="true"
         android:name=".presentation.KerdyApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -143,6 +149,20 @@
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
+        </service>
+
+        <!--suppress AndroidDomInspection -->
+        <service
+            android:name="com.google.android.gms.metadata.ModuleDependencies"
+            android:enabled="false"
+            android:exported="false"
+            tools:ignore="MissingClass">
+            <intent-filter>
+                <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
+            </intent-filter>
+            <meta-data
+                android:name="photopicker_activity:0:required"
+                android:value="" />
         </service>
     </application>
 

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/postWriting/PostWritingActivity.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/postWriting/PostWritingActivity.kt
@@ -2,14 +2,17 @@ package com.emmsale.presentation.ui.postWriting
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.database.Cursor
 import android.net.Uri
 import android.os.Bundle
 import android.provider.MediaStore
+import androidx.activity.result.ActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import com.emmsale.R
 import com.emmsale.databinding.ActivityPostWritingBinding
 import com.emmsale.presentation.common.Event
@@ -30,7 +33,35 @@ class PostWritingActivity : AppCompatActivity() {
         PostWritingImageAdapter(deleteImage = viewModel::deleteImageUrl)
     }
 
-    private val photoPicker = registerForActivityResult(
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setUpBinding()
+        setUpPostUploadResult()
+        setUpImageUrls()
+    }
+
+    // use when build version under 33
+    private val lowVersionAlbumLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
+            val imageUrls = getImageUrlsFromActivityResult(result)
+            viewModel.fetchImageUrls(imageUrls = imageUrls)
+        }
+
+    private fun getImageUrlsFromActivityResult(result: ActivityResult): List<String> {
+        val clipData = result.data?.clipData
+
+        if (clipData != null) {
+            val count = clipData.itemCount
+            return (0 until count).mapNotNull { i ->
+                val uri = clipData.getItemAt(i).uri
+                getAbsolutePathFromUri(uri)
+            }
+        }
+        return emptyList()
+    }
+
+    // use when build version 33
+    private val highVersionAlbumLauncher = registerForActivityResult(
         ActivityResultContracts.PickMultipleVisualMedia(MAX_IMAGE_COUNT),
     ) { uris ->
         viewModel.fetchImageUrls(uris.map { getAbsolutePathFromUri(it) ?: "" })
@@ -44,13 +75,6 @@ class PostWritingActivity : AppCompatActivity() {
             it.moveToFirst()
             it.getString(columnIndex)
         }
-    }
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setUpBinding()
-        setUpPostUploadResult()
-        setUpImageUrls()
     }
 
     private fun setUpBinding() {
@@ -84,25 +108,74 @@ class PostWritingActivity : AppCompatActivity() {
     }
 
     private fun setUpImageUrls() {
-        viewModel.imageUrls.observe(this) {
-            adapter.submitList(it)
+        viewModel.imageUrls.observe(this) { imageUrls ->
+            adapter.submitList(imageUrls)
         }
     }
 
     private fun uploadPost() {
-        if (!viewModel.isTitleValid()) {
-            showToast(getString(R.string.post_writing_title_warning))
-            return
+        when {
+            !viewModel.isTitleValid() -> showToast(getString(R.string.post_writing_title_warning))
+            !viewModel.isContentValid() -> showToast(getString(R.string.post_writing_content_warning))
+            else -> viewModel.uploadPost()
         }
-        if (!viewModel.isContentValid()) {
-            showToast(getString(R.string.post_writing_content_warning))
-            return
-        }
-        viewModel.uploadPost()
     }
 
     private fun showAlbum() {
-        photoPicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+        if (android.os.Build.VERSION.SDK_INT >= 33) {
+            highVersionAlbumLauncher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+        } else {
+            when {
+                isImageAccessPermissionGranted() -> {
+                    val intent = Intent().apply {
+                        type = "image/*"
+                        putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+                        action = Intent.ACTION_PICK
+                    }
+                    lowVersionAlbumLauncher.launch(intent)
+                }
+
+                shouldShowRequestPermissionRationale(android.Manifest.permission.READ_EXTERNAL_STORAGE) -> {
+                    requestPermissions(
+                        arrayOf(android.Manifest.permission.READ_EXTERNAL_STORAGE),
+                        REQUEST_STORAGE,
+                    )
+                }
+
+                else -> {
+                    requestPermissions(
+                        arrayOf(android.Manifest.permission.READ_EXTERNAL_STORAGE),
+                        REQUEST_STORAGE,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun isImageAccessPermissionGranted(): Boolean {
+        return ContextCompat.checkSelfPermission(
+            this,
+            android.Manifest.permission.READ_EXTERNAL_STORAGE,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray,
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        when (requestCode) {
+            REQUEST_STORAGE -> {
+                if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    showAlbum()
+                } else {
+                    showToast(getString(R.string.post_writing_image_permission_denied_message))
+                }
+            }
+
+            else -> Unit
+        }
     }
 
     private fun navigateToBack() {
@@ -111,6 +184,7 @@ class PostWritingActivity : AppCompatActivity() {
 
     companion object {
         private const val MAX_IMAGE_COUNT = 5
+        private const val REQUEST_STORAGE = 1000
 
         fun startActivity(context: Context, eventId: Long) {
             val intent = Intent(context, PostWritingActivity::class.java)

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/postWriting/PostWritingActivity.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/postWriting/PostWritingActivity.kt
@@ -44,7 +44,16 @@ class PostWritingActivity : AppCompatActivity() {
     private val lowVersionAlbumLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
             val imageUrls = getImageUrlsFromActivityResult(result)
-            viewModel.fetchImageUrls(imageUrls = imageUrls)
+            when {
+                imageUrls.size > MAX_IMAGE_COUNT -> {
+                    showAlbum()
+                    showToast(R.string.post_writing_max_image_count_warning_message)
+                }
+
+                imageUrls.isEmpty() -> Unit
+
+                else -> viewModel.fetchImageUrls(imageUrls = imageUrls)
+            }
         }
 
     private fun getImageUrlsFromActivityResult(result: ActivityResult): List<String> {

--- a/android/2023-emmsale/app/src/main/res/values/strings.xml
+++ b/android/2023-emmsale/app/src/main/res/values/strings.xml
@@ -429,5 +429,6 @@
     <string name="feeddetail_toolbar_title">게시글</string>
     <string name="post_writing_title_warning">제목을 입력해 주세요</string>
     <string name="post_writing_content_warning">내용은 8자 이상이어야 합니다</string>
+    <string name="post_writing_image_permission_denied_message">사진 권한이 거부되었습니다.</string>
 
 </resources>

--- a/android/2023-emmsale/app/src/main/res/values/strings.xml
+++ b/android/2023-emmsale/app/src/main/res/values/strings.xml
@@ -398,6 +398,10 @@
     <string name="post_writing_content_hint">내용을 입력하세요.</string>
     <string name="post_writing_upload_error">업로드에 실패하였습니다</string>
     <string name="post_writing_empty_title_content_message">제목 또는 내용을 채워주세요!!</string>
+    <string name="post_writing_title_warning">제목을 입력해 주세요</string>
+    <string name="post_writing_content_warning">내용은 8자 이상이어야 합니다</string>
+    <string name="post_writing_image_permission_denied_message">사진 권한이 거부되었습니다.</string>
+    <string name="post_writing_max_image_count_warning_message">최대 5장까지만 선택 가능합니다</string>
 
     <string name="messageroom_toolbar_title">메시지</string>
     <string name="messageroom_message_room_options_title">더보기</string>
@@ -427,9 +431,4 @@
     <string name="feeddetaildeletedialog_title">게시글 삭제</string>
     <string name="feeddetaildeletedialog_message">해당 게시글을 삭제하시겠습니까?</string>
     <string name="feeddetail_toolbar_title">게시글</string>
-    <string name="post_writing_title_warning">제목을 입력해 주세요</string>
-    <string name="post_writing_content_warning">내용은 8자 이상이어야 합니다</string>
-    <string name="post_writing_image_permission_denied_message">사진 권한이 거부되었습니다.</string>
-    <string name="post_writing_max_image_count_warning_message">최대 5장까지만 선택 가능합니다</string>
-
 </resources>

--- a/android/2023-emmsale/app/src/main/res/values/strings.xml
+++ b/android/2023-emmsale/app/src/main/res/values/strings.xml
@@ -430,5 +430,6 @@
     <string name="post_writing_title_warning">제목을 입력해 주세요</string>
     <string name="post_writing_content_warning">내용은 8자 이상이어야 합니다</string>
     <string name="post_writing_image_permission_denied_message">사진 권한이 거부되었습니다.</string>
+    <string name="post_writing_max_image_count_warning_message">최대 5장까지만 선택 가능합니다</string>
 
 </resources>


### PR DESCRIPTION
## #️⃣연관된 이슈
>  #706 

## 📝작업 내용
> photoPicker 만으로 해결하려다가 실패하였습니다...
> 안드로이드 13 이상 버젼 (티라미슈) 버젼에서는 photoPickerLauncher 를 그대로 사용하고, 그 미만의 버젼에서는 기존의 문서 편집기를 사용하여 코드를 변경하였습니다.
> 안드로이드 13 미만 버젼에서는 권한 요청을 추가로 해주어야 했습니다.

### 스크린샷 (선택)
[33이상사진구현.webm](https://github.com/woowacourse-teams/2023-emmsale/assets/76036731/44d0685e-9dbb-4e83-9d73-4a8679b45c62)

[33권한이하사진.webm](https://github.com/woowacourse-teams/2023-emmsale/assets/76036731/508b2fdb-de8d-426c-a418-52b3b999cc10)


## 예상 소요 시간 및 실제 소요 시간
> 이슈의 예상 소요 시간과 실제 소요된 시간을 분 or 시간 or 일 단위로 작성해주세요.
2시간/ 3시간
