### PR TITLE
fix(LocalDateTimeExt): 상대 시간 계산 로직 수정

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/common/extension/LocalDateTimeExt.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/common/extension/LocalDateTimeExt.kt
@@ -8,6 +8,7 @@ import com.emmsale.R
 import java.time.Duration
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import java.util.Locale
 import kotlin.math.abs
 
@@ -34,7 +35,10 @@ fun LocalDateTime.toRelativeTime(
 
         durationHours < MIN_HOUR -> {
             val dateFormatter = DateTimeFormatter.ofPattern(
-                context.getString(R.string.before_minute_format, durationHours),
+                context.getString(
+                    R.string.before_minute_format,
+                    abs(ChronoUnit.MINUTES.between(standardTime, this)),
+                ),
             )
             format(dateFormatter)
         }


### PR DESCRIPTION
- 항상 0분 전으로 보이던 것을 제대로 된 분 차이를 보여주도록 수정

## #️⃣연관된 이슈
>  #717 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)


## 예상 소요 시간 및 실제 소요 시간
> 이슈의 예상 소요 시간과 실제 소요된 시간을 분 or 시간 or 일 단위로 작성해주세요.
> 
> 5분/5분


## 💬리뷰 요구사항(선택)

> 한 줄 고쳤으므로 바로 머지하겠습니다.