### PR TITLE
Hotfix/#722 에뮬레이터 splash activity에서 다음화면으로 넘어가지 못하는 버그

### DIFF
--- a/android/2023-emmsale/app/build.gradle.kts
+++ b/android/2023-emmsale/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.emmsale"
         minSdk = 28
         targetSdk = 33
-        versionCode = 45
+        versionCode = 49
         versionName = "2.0.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/splash/SplashActivity.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/splash/SplashActivity.kt
@@ -71,7 +71,7 @@ class SplashActivity : ComponentActivity() {
 
         appUpdateManager.appUpdateInfo.addListener(
             onSuccess = { updateInfo -> updateInfo.handleUpdateInfo(isAutoLogin) },
-            onFailed = { showToast(R.string.all_network_error_title) },
+            onFailed = { navigateToNextScreen(isAutoLogin) },
         )
     }
 

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/splash/SplashActivity.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/splash/SplashActivity.kt
@@ -71,7 +71,10 @@ class SplashActivity : ComponentActivity() {
 
         appUpdateManager.appUpdateInfo.addListener(
             onSuccess = { updateInfo -> updateInfo.handleUpdateInfo(isAutoLogin) },
-            onFailed = { navigateToNextScreen(isAutoLogin) },
+            onFailed = {
+                showToast(R.string.splash_not_installed_playstore)
+                navigateToPlayStore()
+            },
         )
     }
 
@@ -87,7 +90,7 @@ class SplashActivity : ComponentActivity() {
             this,
             title = getString(R.string.splash_app_update_title),
             message = getString(R.string.splash_app_update_message),
-            onPositiveButtonClick = ::navigateToAppStore,
+            onPositiveButtonClick = ::navigateToPlayStore,
             onNegativeButtonClick = {
                 showToast(R.string.splash_app_update_canceled_message)
                 finishAffinity()
@@ -95,9 +98,11 @@ class SplashActivity : ComponentActivity() {
         ).show()
     }
 
-    private fun navigateToAppStore() {
-        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=$packageName")))
-        finish()
+    private fun navigateToPlayStore() {
+        val intent = Intent(Intent.ACTION_VIEW)
+            .addCategory(Intent.CATEGORY_BROWSABLE)
+            .setData(Uri.parse("https://play.google.com/store/apps/details?id=$packageName"))
+        startActivity(intent)
     }
 
     private fun navigateToNextScreen(isAutoLogin: Boolean) {

--- a/android/2023-emmsale/app/src/main/res/values/strings.xml
+++ b/android/2023-emmsale/app/src/main/res/values/strings.xml
@@ -446,4 +446,6 @@
     <string name="eventsearch_delete_all_query_dialog_desc">최근 검색어를 모두 삭제하시겠어요?</string>
     <string name="all_image_permission_request_dialog_message">이미지 권한 허용을 위해 설정창으로 이동하시겠습니까?</string>
     <string name="all_image_permission_request_dialog_title">이미지 권한이 거부되었어요</string>
+
+    <string name="splash_not_installed_playstore">플레이스토어가 설치되지 않았거나 로그인하지 않았어요 😥</string>
 </resources>


### PR DESCRIPTION
## #️⃣연관된 이슈
> #722

## 📝작업 내용
> vesionCode 49로 업데이트
> 인앱 업데이트 실패 시, 다음 화면으로 이동

> 1줄 바꿨고, 오류가 뜨는 이유는, 앱에 Playstore가 깔려있지 않으면, 인앱 업데이트가 실패해서, OnFailure 로 넘어가는데, 이때도 다음 화면으로 넘어가게 해주어야 앱 심사가 통과할 것 같아서 이렇게 바꿨습니다.

## 예상 소요 시간 및 실제 소요 시간
30분/ 30분
