### PR TITLE
Fix/#726 행사 목록 조회 시 행사 날짜만을 기준으로 정렬하는 문제

### DIFF
--- a/backend/emm-sale/src/documentTest/java/com/emmsale/EventApiTest.java
+++ b/backend/emm-sale/src/documentTest/java/com/emmsale/EventApiTest.java
@@ -23,7 +23,6 @@ import com.emmsale.event.domain.PaymentType;
 import com.emmsale.tag.TagFixture;
 import com.emmsale.tag.application.dto.TagRequest;
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -171,7 +170,7 @@ class EventApiTest extends MockMvcTestHelper {
     );
 
     Mockito.when(eventService.findEvents(any(EventType.class),
-        any(LocalDate.class), eq("2023-07-01"),
+        any(LocalDateTime.class), eq("2023-07-01"),
         eq("2023-07-31"),
         eq(null), any(), eq("컨퍼"))).thenReturn(eventResponses);
 

--- a/backend/emm-sale/src/main/java/com/emmsale/event/api/EventApi.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/api/EventApi.java
@@ -7,6 +7,7 @@ import com.emmsale.event.application.dto.EventResponse;
 import com.emmsale.event.domain.EventStatus;
 import com.emmsale.event.domain.EventType;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -46,7 +47,7 @@ public class EventApi {
       @RequestParam(required = false) final List<EventStatus> statuses,
       @RequestParam(required = false) final String keyword) {
     return ResponseEntity.ok(
-        eventService.findEvents(category, LocalDate.now(), startDate, endDate, tags, statuses,
+        eventService.findEvents(category, LocalDateTime.now(), startDate, endDate, tags, statuses,
             keyword));
   }
 

--- a/backend/emm-sale/src/main/java/com/emmsale/event/application/EventService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/application/EventService.java
@@ -92,7 +92,7 @@ public class EventService {
 
   @Transactional(readOnly = true)
   public List<EventResponse> findEvents(final EventType category,
-      final LocalDate nowDate, final String startDate, final String endDate,
+      final LocalDateTime nowDate, final String startDate, final String endDate,
       final List<String> tagNames, final List<EventStatus> statuses, final String keyword) {
     Specification<Event> spec = (root, query, criteriaBuilder) -> null;
     spec = filterByCategoryIfExist(category, spec);
@@ -210,7 +210,7 @@ public class EventService {
     return keyword != null && !keyword.isBlank();
   }
 
-  private EnumMap<EventStatus, List<Event>> groupByEventStatus(final LocalDate nowDate,
+  private EnumMap<EventStatus, List<Event>> groupByEventStatus(final LocalDateTime nowDate,
       final List<Event> events) {
     return events.stream()
         .sorted(comparing(event -> event.getEventPeriod().getStartDate()))

--- a/backend/emm-sale/src/main/java/com/emmsale/event/application/EventService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/application/EventService.java
@@ -92,7 +92,7 @@ public class EventService {
 
   @Transactional(readOnly = true)
   public List<EventResponse> findEvents(final EventType category,
-      final LocalDateTime nowDate, final String startDate, final String endDate,
+      final LocalDateTime nowDateTime, final String startDate, final String endDate,
       final List<String> tagNames, final List<EventStatus> statuses, final String keyword) {
     Specification<Event> spec = (root, query, criteriaBuilder) -> null;
     spec = filterByCategoryIfExist(category, spec);
@@ -103,7 +103,7 @@ public class EventService {
     final List<Event> events = eventRepository.findAll(spec);
 
     final EnumMap<EventStatus, List<Event>> eventsForEventStatus
-        = groupByEventStatus(nowDate, events);
+        = groupByEventStatus(nowDateTime, events);
 
     return filterByStatuses(statuses, eventsForEventStatus, makeImageUrlPerEventId(events));
   }
@@ -210,12 +210,12 @@ public class EventService {
     return keyword != null && !keyword.isBlank();
   }
 
-  private EnumMap<EventStatus, List<Event>> groupByEventStatus(final LocalDateTime nowDate,
+  private EnumMap<EventStatus, List<Event>> groupByEventStatus(final LocalDateTime nowDateTime,
       final List<Event> events) {
     return events.stream()
         .sorted(comparing(event -> event.getEventPeriod().getStartDate()))
         .collect(
-            groupingBy(event -> event.getEventPeriod().calculateEventStatus(nowDate),
+            groupingBy(event -> event.getEventPeriod().calculateEventStatus(nowDateTime),
                 () -> new EnumMap<>(EventStatus.class), toList())
         );
   }

--- a/backend/emm-sale/src/main/java/com/emmsale/event/domain/EventPeriod.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/domain/EventPeriod.java
@@ -56,11 +56,11 @@ public class EventPeriod {
     }
   }
 
-  public EventStatus calculateEventStatus(final LocalDate now) {
-    if (now.isBefore(startDate.toLocalDate())) {
+  public EventStatus calculateEventStatus(final LocalDateTime now) {
+    if (now.isBefore(startDate)) {
       return EventStatus.UPCOMING;
     }
-    if (now.isAfter(endDate.toLocalDate())) {
+    if (now.isAfter(endDate)) {
       return EventStatus.ENDED;
     }
     return EventStatus.IN_PROGRESS;

--- a/backend/emm-sale/src/main/java/com/emmsale/event/domain/EventPeriod.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/domain/EventPeriod.java
@@ -66,20 +66,23 @@ public class EventPeriod {
     return EventStatus.IN_PROGRESS;
   }
 
+  @Deprecated
   public int calculateRemainingDays(final LocalDate today) {
     return java.time.Period.between(today, startDate.toLocalDate()).getDays();
   }
 
-  public EventStatus calculateEventApplyStatus(final LocalDate now) {
-    if (now.isBefore(applyStartDate.toLocalDate())) {
+  @Deprecated
+  public EventStatus calculateEventApplyStatus(final LocalDateTime now) {
+    if (now.isBefore(applyStartDate)) {
       return EventStatus.UPCOMING;
     }
-    if (now.isAfter(applyEndDate.toLocalDate())) {
+    if (now.isAfter(applyEndDate)) {
       return EventStatus.ENDED;
     }
     return EventStatus.IN_PROGRESS;
   }
 
+  @Deprecated
   public int calculateApplyRemainingDays(final LocalDate today) {
     return java.time.Period.between(today, applyStartDate.toLocalDate()).getDays();
   }

--- a/backend/emm-sale/src/main/java/com/emmsale/scrap/application/ScrapQueryService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/scrap/application/ScrapQueryService.java
@@ -10,7 +10,7 @@ import com.emmsale.image.domain.repository.ImageRepository;
 import com.emmsale.member.domain.Member;
 import com.emmsale.scrap.domain.Scrap;
 import com.emmsale.scrap.domain.ScrapRepository;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +35,8 @@ public class ScrapQueryService {
         .collect(Collectors.toList());
 
     final Map<EventStatus, List<Event>> eventGroupByStatus = scrappedEvents.stream()
-        .collect(groupingBy(event -> event.getEventPeriod().calculateEventStatus(LocalDate.now())));
+        .collect(
+            groupingBy(event -> event.getEventPeriod().calculateEventStatus(LocalDateTime.now())));
 
     return EventResponse.mergeEventResponses(eventGroupByStatus,
         makeImageUrlPerEventId(scrappedEvents));

--- a/backend/emm-sale/src/test/java/com/emmsale/event/application/EventServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/application/EventServiceTest.java
@@ -90,7 +90,7 @@ class EventServiceTest extends ServiceIntegrationTestHelper {
   private static final EventResponse 구름톤 = new EventResponse(null, "구름톤", null, null, null, null,
       List.of(), null, EventMode.ONLINE.getValue(), PaymentType.PAID.getValue());
 
-  private static final LocalDate TODAY = LocalDate.of(2023, 7, 21);
+  private static final LocalDateTime TODAY = LocalDateTime.of(2023, 7, 21, 0, 0);
   @Autowired
   private EventService eventService;
   @Autowired

--- a/backend/emm-sale/src/test/java/com/emmsale/event/domain/EventTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/domain/EventTest.java
@@ -275,6 +275,7 @@ class EventTest {
         exception.exceptionType());
   }
 
+  @Deprecated
   @Test
   @DisplayName("현재날짜로부터 남은 날짜를 계산할 수 있다.")
   void calculateRemainingDay() {
@@ -290,6 +291,7 @@ class EventTest {
         .isEqualTo(5);
   }
 
+  @Deprecated
   @Test
   @DisplayName("현재날짜로부터 신청 시작일까지 남은 날짜를 계산할 수 있다.")
   void calculateApplyRemainingDay() {

--- a/backend/emm-sale/src/test/java/com/emmsale/event/domain/EventTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/domain/EventTest.java
@@ -31,10 +31,12 @@ import org.junit.jupiter.params.provider.CsvSource;
 class EventTest {
 
   @ParameterizedTest
-  @CsvSource(value = {"2023-03-01,UPCOMING", "2023-07-25,IN_PROGRESS",
-      "2023-08-01,ENDED"}, delimiter = ',')
+  @CsvSource(value = {"2023-03-01T00:00:00,UPCOMING", "2023-07-25T00:00:00,IN_PROGRESS",
+      "2023-08-01T00:00:00,ENDED", "2023-07-22T12:00:00,IN_PROGRESS",
+      "2023-07-22T12:00:01,IN_PROGRESS", "2023-07-30T12:00:00,IN_PROGRESS",
+      "2023-07-30T12:00:01,ENDED"}, delimiter = ',')
   @DisplayName("현재 날짜가 주어지면 행사의 진행 상태를 계산한다.")
-  void calculateEventStatus(LocalDate input, EventStatus expected) {
+  void calculateEventStatus(LocalDateTime input, EventStatus expected) {
     // given, when
     EventStatus actual = EventFixture.AI_컨퍼런스().getEventPeriod().calculateEventStatus(input);
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#726

## 📝작업 내용
행사 목록 조회 시 행사 날짜+시간까지 기준으로 하여 목록을 정렬하도록 수정

## 예상 소요 시간 및 실제 소요 시간
10/16(월) 10/16(월)
