### PR TITLE
Refactor/#732 이미지 불러오는 속도 개선

### DIFF
--- a/android/2023-emmsale/app/src/main/AndroidManifest.xml
+++ b/android/2023-emmsale/app/src/main/AndroidManifest.xml
@@ -12,13 +12,13 @@
         android:maxSdkVersion="32" />
 
     <application
-        android:requestLegacyExternalStorage="true"
         android:name=".presentation.KerdyApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:requestLegacyExternalStorage="true"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Emmsale"
@@ -53,10 +53,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity
-            android:name=".presentation.ui.openProfileUrlConfig.OpenProfileUrlConfigActivity"
-            android:screenOrientation="portrait"
-            tools:ignore="LockedOrientationActivity" />
         <activity
             android:name=".presentation.ui.myPostList.MyPostActivity"
             android:screenOrientation="portrait"

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/competitionList/recyclerView/CompetitionRecyclerViewAdapter.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/competitionList/recyclerView/CompetitionRecyclerViewAdapter.kt
@@ -1,7 +1,9 @@
 package com.emmsale.presentation.ui.competitionList.recyclerView
 
+import android.content.Context
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
+import com.bumptech.glide.Glide
 import com.emmsale.data.model.Event
 import com.emmsale.presentation.ui.conferenceList.recyclerView.EventDiffUtil
 
@@ -15,5 +17,24 @@ class CompetitionRecyclerViewAdapter(
 
     override fun onBindViewHolder(holder: CompetitionViewHolder, position: Int) {
         holder.bind(getItem(position))
+        preload(holder.itemView.context, position)
+    }
+
+    private fun preload(context: Context, currentPosition: Int) {
+        val endPosition = (currentPosition + PRELOAD_SIZE).coerceAtMost(currentList.size - 1)
+
+        currentList
+            .subList(currentPosition, endPosition)
+            .forEach { event -> preload(context, event.posterUrl) }
+    }
+
+    private fun preload(context: Context, url: String?) {
+        Glide.with(context)
+            .load(url)
+            .preload()
+    }
+
+    companion object {
+        private const val PRELOAD_SIZE = 8
     }
 }

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/conferenceList/recyclerView/ConferenceRecyclerViewAdapter.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/conferenceList/recyclerView/ConferenceRecyclerViewAdapter.kt
@@ -1,18 +1,41 @@
 package com.emmsale.presentation.ui.conferenceList.recyclerView
 
+import android.content.Context
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
+import com.bumptech.glide.Glide
 import com.emmsale.data.model.Event
 
 class ConferenceRecyclerViewAdapter(
     private val onClickConference: (Event) -> Unit,
 ) : ListAdapter<Event, ConferenceViewHolder>(EventDiffUtil) {
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ConferenceViewHolder =
-        ConferenceViewHolder(parent, onClickConference)
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): ConferenceViewHolder = ConferenceViewHolder(parent, onClickConference)
 
     override fun getItemCount(): Int = currentList.size
 
     override fun onBindViewHolder(holder: ConferenceViewHolder, position: Int) {
         holder.bind(getItem(position))
+        preload(holder.itemView.context, position)
+    }
+
+    private fun preload(context: Context, currentPosition: Int) {
+        val endPosition = (currentPosition + PRELOAD_SIZE).coerceAtMost(currentList.size - 1)
+
+        currentList
+            .subList(currentPosition, endPosition)
+            .forEach { event -> preload(context, event.posterUrl) }
+    }
+
+    private fun preload(context: Context, url: String?) {
+        Glide.with(context)
+            .load(url)
+            .preload()
+    }
+
+    companion object {
+        private const val PRELOAD_SIZE = 8
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close : #732 

## 📝 작업 내용
- 행사, 대회 리사이클러뷰에서 이미지를 미리 불러와서 캐싱하는 기능 구현

### 스크린샷 (선택)
**Before**
회색 배경이 오래 보이는 문제

<img width="478" alt="스크린샷 2023-10-18 오전 1 26 53" src="https://github.com/woowacourse-teams/2023-emmsale/assets/56534241/2fbb841e-7f7a-42d4-b53b-620e174ce33d">

**After**
회색 배경이 짧게 보이거나, 아예 보이지 않도록 변경

<img width="479" alt="스크린샷 2023-10-18 오전 1 27 54" src="https://github.com/woowacourse-teams/2023-emmsale/assets/56534241/84eb2461-8bec-43c6-867f-cb78dc8754cc">

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)
예상 소요 시간 : 1시간
실제 소요 시간 : 30분


## 💬 리뷰어 요구사항 (선택)
