### PR TITLE
Feature/#741 앱 업데이트 다이얼로그 외부 클릭 방지

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/common/views/ConfirmDialog.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/common/views/ConfirmDialog.kt
@@ -18,6 +18,7 @@ class ConfirmDialog(
     private val negativeButtonLabel: String = context.getString(R.string.all_cancel),
     private val onPositiveButtonClick: () -> Unit = {},
     private val onNegativeButtonClick: () -> Unit = {},
+    private val cancelable: Boolean = true,
     private val onCancel: () -> Unit = {},
 ) : Dialog(context) {
     private val binding: DialogConfirmBinding by lazy { DialogConfirmBinding.inflate(layoutInflater) }
@@ -26,6 +27,7 @@ class ConfirmDialog(
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
 
+        setCanceledOnTouchOutside(cancelable)
         initDialogWindow()
         initDataBinding()
         setOnCancelListener { onCancel() }

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/splash/SplashActivity.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/splash/SplashActivity.kt
@@ -95,6 +95,7 @@ class SplashActivity : ComponentActivity() {
                 showToast(R.string.splash_app_update_canceled_message)
                 finishAffinity()
             },
+            cancelable = false,
         ).show()
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close : #741

## 📝 작업 내용
앱 업데이트 다이얼로그 외부 클릭이 안 되도록 변경하였습니다.

### 스크린샷 (선택)

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)
예상 소요 시간 : 10분
실제 소요 시간 : 10분

## 💬 리뷰어 요구사항 (선택)



