### PR TITLE
fix: 지난 달의 메시지 시간이 방금 전으로 보이는 버그 수정

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/common/extension/LocalDateTimeExt.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/common/extension/LocalDateTimeExt.kt
@@ -55,9 +55,8 @@ fun LocalDateTime.toMessageRelativeTime(
         return format(DateTimeFormatter.ofPattern(context.getString(R.string.year_month_day)))
     }
 
-    if (year == standardTime.year &&
-        monthValue <= standardTime.monthValue &&
-        dayOfMonth < standardTime.dayOfMonth
+    if ((year == standardTime.year && monthValue < standardTime.monthValue) ||
+        (monthValue == standardTime.monthValue && dayOfMonth < standardTime.dayOfMonth)
     ) {
         return format(DateTimeFormatter.ofPattern(context.getString(R.string.month_day)))
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close : #749

## 📝 작업 내용

메시지함에서 이전 달 메시지의 시간이 방금 전으로 보이는 버그를 수정했습니다.
확인해보니 `toMessageRelativeTime()` 메서드에 지난 달을 판단하는 로직에 버그에 문제가 있었습니다.

기존에는 맨 마지막 BuNa의 메시지 시간이 `방금 전`으로 보였지만, 버그 수정 후 9월 26일(정상적으로)로 보이고 있습니다. 👍

### 스크린샷 (선택)
<img width="429" alt="스크린샷 2023-10-19 오전 10 41 10" src="https://github.com/woowacourse-teams/2023-emmsale/assets/56534241/75d46a2e-32f0-4c59-9c98-2470f8438f43">

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)
예상 소요 시간 : 20분
실제 소요 시간 : 20분

## 💬 리뷰어 요구사항 (선택)



