### PR TITLE
fix: onResume 에서 메세지 업데이트 하도록 변경

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageRoomList/MessageRoomFragment.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageRoomList/MessageRoomFragment.kt
@@ -18,6 +18,11 @@ class MessageRoomFragment : BaseFragment<FragmentMessageRoomBinding>() {
 
     private lateinit var messageRoomListAdapter: MessageRoomListAdapter
 
+    override fun onResume() {
+        super.onResume()
+        viewModel.refresh()
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupBinding()

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageRoomList/MessageRoomViewModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageRoomList/MessageRoomViewModel.kt
@@ -24,10 +24,6 @@ class MessageRoomViewModel @Inject constructor(
     private val _messageRooms = NotNullMutableLiveData(MemberRoomListUiState())
     val messageRooms: NotNullLiveData<MemberRoomListUiState> = _messageRooms
 
-    init {
-        refresh()
-    }
-
     override fun refresh() {
         fetchMessageRooms()
     }

--- a/android/2023-emmsale/app/src/main/res/layout/fragment_message_room.xml
+++ b/android/2023-emmsale/app/src/main/res/layout/fragment_message_room.xml
@@ -27,10 +27,10 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:menu="@menu/menu_message_room_toolbar"
             app:title="@string/messageroom_toolbar_title"
             app:titleCentered="true"
             app:titleTextAppearance="@style/ToolbarTitleFontStyle" />
+<!--app:menu="@menu/menu_message_room_toolbar" 삭제 기능 구현시 추가 예정-->
 
         <View
             android:id="@+id/divider"


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close : #758

## 📝 작업 내용
onResume 에서 메세지Room을 업데이트 하도록 변경했습니다

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)
예상 소요 시간 : 10분
실제 소요 시간 : 10분

## 💬 리뷰어 요구사항 (선택)



