### PR TITLE
Fix/#761 다크모드 디자인 수정

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/profile/SendMessageDialog.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/profile/SendMessageDialog.kt
@@ -1,12 +1,13 @@
 package com.emmsale.presentation.ui.profile
 
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.activityViewModels
-import com.emmsale.R
 import com.emmsale.databinding.DialogSendMessageBinding
 
 class SendMessageDialog : DialogFragment() {
@@ -23,18 +24,21 @@ class SendMessageDialog : DialogFragment() {
         savedInstanceState: Bundle?,
     ): View {
         _binding = DialogSendMessageBinding.inflate(inflater, container, false)
-        binding.lifecycleOwner = viewLifecycleOwner
+        setupWindow()
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initDataBinding()
+        setupDataBinding()
     }
 
-    override fun getTheme(): Int = R.style.RoundBottomSheetDialogStyle
+    private fun setupWindow() {
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+    }
 
-    private fun initDataBinding() {
+    private fun setupDataBinding() {
+        binding.lifecycleOwner = viewLifecycleOwner
         binding.vm = viewModel
         binding.onSendButtonClick = ::onSendButtonClick
         binding.onCancelButtonClick = ::onCancelButtonClick

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/recruitmentDetail/SendMessageDialog.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/recruitmentDetail/SendMessageDialog.kt
@@ -24,18 +24,21 @@ class SendMessageDialog : DialogFragment() {
         savedInstanceState: Bundle?,
     ): View {
         _binding = DialogRecruitmentpostdetailSendMessageBinding.inflate(inflater, container, false)
-        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
-        binding.lifecycleOwner = viewLifecycleOwner
+        setupWindow()
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        initDataBinding()
+        setupDataBinding()
     }
 
-    private fun initDataBinding() {
+    private fun setupWindow() {
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+    }
+
+    private fun setupDataBinding() {
+        binding.lifecycleOwner = viewLifecycleOwner
         binding.vm = viewModel
         binding.onSendButtonClick = ::onSendButtonClick
         binding.onCancelButtonClick = ::onCancelButtonClick

--- a/android/2023-emmsale/app/src/main/res/drawable/bg_requestcompanion_et.xml
+++ b/android/2023-emmsale/app/src/main/res/drawable/bg_requestcompanion_et.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="#FFFFFF" />
     <stroke
         android:width="0.5dp"
         android:color="@color/light_gray" />


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close : #761 

## 📝 작업 내용

다크 모드에서 쪽지 보내기 다이얼로그 띄워지면 상태가 색상이 하늘색으로 변하는 버그 해결
다크 모드에서 쪽지 보내기 다이얼로그의 입력란이 하얀색인 버그 해

### 스크린샷 (선택)

![image](https://github.com/woowacourse-teams/2023-emmsale/assets/123928686/f2b6b8aa-af5f-427f-8d79-6a5c59e8f16c)


## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)
예상 소요 시간 : 10분
실제 소요 시간 : 5분

## 💬 리뷰어 요구사항 (선택)

매우 짧은 코드를 수정했고 논의사항이 없어보이므로 바로 머지하겠습니다!


