### PR TITLE
fix: 게시글 스크롤 및 상세페이지 안되는 버그 해결

### DIFF
--- a/android/2023-emmsale/app/src/main/res/layout/fragment_event_recruitment.xml
+++ b/android/2023-emmsale/app/src/main/res/layout/fragment_event_recruitment.xml
@@ -54,6 +54,7 @@
         <androidx.core.widget.NestedScrollView
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
+            app:visible="@{vm.recruitments.list.empty &amp;&amp; vm.recruitments.fetchResult == FetchResult.SUCCESS}"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
@@ -62,7 +63,6 @@
                 android:layout_height="match_parent"
                 android:layout_marginTop="30dp"
                 app:description="@string/postlist_no_content_view_desc"
-                app:visible="@{vm.recruitments.list.empty &amp;&amp; vm.recruitments.fetchResult == FetchResult.SUCCESS}"
                 app:layout_constraintTop_toTopOf="parent"
                 app:noContentImageResId="@drawable/ic_no_result2"
                 app:title="@string/postlist_no_content_view_title" />

--- a/android/2023-emmsale/app/src/main/res/layout/fragment_post_list.xml
+++ b/android/2023-emmsale/app/src/main/res/layout/fragment_post_list.xml
@@ -56,6 +56,7 @@
         <androidx.core.widget.NestedScrollView
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
+            app:visible="@{vm.posts.posts.empty &amp;&amp; vm.posts.fetchResult == FetchResult.SUCCESS}"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
@@ -64,7 +65,6 @@
                 android:layout_height="match_parent"
                 android:layout_marginTop="30dp"
                 app:description="@string/postlist_no_content_view_desc"
-                app:visible="@{vm.posts.posts.empty &amp;&amp; vm.posts.fetchResult == FetchResult.SUCCESS}"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:noContentImageResId="@drawable/ic_no_result2"


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close : #766

## 📝 작업 내용
-게시글과 함께해요 글 없을 때, nestedScrollView 에 visible을 설정해줘서 버그 해결