### PR TITLE
Feature/#765 푸시 알림 클릭할 때 업데이트 필요 확인하는 기능

### DIFF
--- a/android/2023-emmsale/app/build.gradle.kts
+++ b/android/2023-emmsale/app/build.gradle.kts
@@ -21,7 +21,7 @@ android {
         minSdk = 28
         targetSdk = 33
         versionCode = 54
-        versionName = "2.1.0"
+        versionName = "2.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/android/2023-emmsale/app/build.gradle.kts
+++ b/android/2023-emmsale/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.emmsale"
         minSdk = 28
         targetSdk = 33
-        versionCode = 53
+        versionCode = 54
         versionName = "2.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/android/2023-emmsale/app/src/main/AndroidManifest.xml
+++ b/android/2023-emmsale/app/src/main/AndroidManifest.xml
@@ -4,8 +4,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-
-    <!--Image Permission-->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
@@ -25,111 +23,45 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="33">
         <activity android:name=".presentation.ui.eventSearch.EventSearchActivity" />
-        <activity
-            android:name=".presentation.ui.feedDetail.FeedDetailActivity"
-            android:exported="false"
-
-            tools:ignore="LockedOrientationActivity" />
+        <activity android:name=".presentation.ui.feedDetail.FeedDetailActivity" />
         <activity
             android:name=".presentation.ui.messageList.MessageListActivity"
             android:launchMode="singleTask"
-
-            android:windowSoftInputMode="adjustResize|stateVisible"
-            tools:ignore="LockedOrientationActivity" />
-        <activity
-            android:name=".presentation.ui.postWriting.PostWritingActivity"
-            android:exported="false"
-
-            tools:ignore="LockedOrientationActivity" />
+            android:windowSoftInputMode="adjustResize" />
+        <activity android:name=".presentation.ui.postWriting.PostWritingActivity" />
         <activity
             android:name=".presentation.ui.splash.SplashActivity"
             android:exported="true"
-
-            android:theme="@style/Theme.Emmsale.SplashScreen"
-            tools:ignore="LockedOrientationActivity">
+            android:theme="@style/Theme.Emmsale.SplashScreen">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity
-            android:name=".presentation.ui.myPostList.MyPostActivity"
-
-            tools:ignore="LockedOrientationActivity" />
-        <activity
-            android:name=".presentation.ui.notificationTagConfig.NotificationTagConfigActivity"
-
-            tools:ignore="LockedOrientationActivity" />
-        <activity
-            android:name=".presentation.ui.myCommentList.MyCommentsActivity"
-
-            tools:ignore="LockedOrientationActivity" />
-        <activity
-            android:name=".presentation.ui.blockMemberList.MemberBlockActivity"
-
-            tools:ignore="LockedOrientationActivity" />
-        <activity
-            android:name=".presentation.ui.notificationConfig.NotificationConfigActivity"
-
-            tools:ignore="LockedOrientationActivity" />
-        <activity
-            android:name=".presentation.ui.recruitmentWriting.RecruitmentPostWritingActivity"
-
-            tools:ignore="LockedOrientationActivity" />
-        <activity
-            android:name=".presentation.ui.recruitmentDetail.RecruitmentPostDetailActivity"
-
-            tools:ignore="LockedOrientationActivity" />
-        <activity
-            android:name=".presentation.ui.editMyProfile.EditMyProfileActivity"
-
-            tools:ignore="LockedOrientationActivity" />
-        <activity
-            android:name=".presentation.ui.profile.ProfileActivity"
-
-            tools:ignore="LockedOrientationActivity" />
-        <activity
-            android:name=".presentation.ui.notificationPageList.NotificationBoxActivity"
-
-            tools:ignore="LockedOrientationActivity" />
-        <activity
-            android:name=".presentation.ui.childCommentList.ChildCommentActivity"
-
-            tools:ignore="LockedOrientationActivity" />
-        <activity
-            android:name=".presentation.ui.useTerm.UseTermWebViewActivity"
-
-            tools:ignore="LockedOrientationActivity" />
-        <activity
-            android:name=".presentation.ui.conferenceFilter.ConferenceFilterActivity"
-
-            tools:ignore="LockedOrientationActivity" />
-        <activity
-            android:name=".presentation.ui.competitionFilter.CompetitionFilterActivity"
-
-            tools:ignore="LockedOrientationActivity" />
+        <activity android:name=".presentation.ui.myPostList.MyPostActivity" />
+        <activity android:name=".presentation.ui.notificationTagConfig.NotificationTagConfigActivity" />
+        <activity android:name=".presentation.ui.myCommentList.MyCommentsActivity" />
+        <activity android:name=".presentation.ui.blockMemberList.MemberBlockActivity" />
+        <activity android:name=".presentation.ui.notificationConfig.NotificationConfigActivity" />
+        <activity android:name=".presentation.ui.recruitmentWriting.RecruitmentPostWritingActivity" />
+        <activity android:name=".presentation.ui.recruitmentDetail.RecruitmentPostDetailActivity" />
+        <activity android:name=".presentation.ui.editMyProfile.EditMyProfileActivity" />
+        <activity android:name=".presentation.ui.profile.ProfileActivity" />
+        <activity android:name=".presentation.ui.notificationPageList.NotificationBoxActivity" />
+        <activity android:name=".presentation.ui.childCommentList.ChildCommentActivity" />
+        <activity android:name=".presentation.ui.useTerm.UseTermWebViewActivity" />
+        <activity android:name=".presentation.ui.conferenceFilter.ConferenceFilterActivity" />
+        <activity android:name=".presentation.ui.competitionFilter.CompetitionFilterActivity" />
         <activity
             android:name=".presentation.ui.main.MainActivity"
-            android:exported="true"
-            android:launchMode="singleTask"
-
-            tools:ignore="LockedOrientationActivity" />
-        <activity
-            android:name=".presentation.ui.onboarding.OnboardingActivity"
-
-            tools:ignore="LockedOrientationActivity" />
-        <activity
-            android:name=".presentation.ui.eventDetail.EventDetailActivity"
-
-            tools:ignore="LockedOrientationActivity" />
+            android:launchMode="singleTask" />
+        <activity android:name=".presentation.ui.onboarding.OnboardingActivity" />
+        <activity android:name=".presentation.ui.eventDetail.EventDetailActivity" />
         <activity
             android:name=".presentation.ui.login.LoginActivity"
             android:exported="true"
             android:launchMode="singleTask"
-
-            android:theme="@style/Theme.Emmsale.FullScreen"
-            tools:ignore="LockedOrientationActivity">
+            android:theme="@style/Theme.Emmsale.FullScreen">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/common/extension/AppUpdateInfoExt.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/common/extension/AppUpdateInfoExt.kt
@@ -2,12 +2,11 @@ package com.emmsale.presentation.common.extension
 
 import com.google.android.gms.tasks.Task
 import com.google.android.play.core.appupdate.AppUpdateInfo
-import com.google.android.play.core.install.model.AppUpdateType
 import com.google.android.play.core.install.model.UpdateAvailability
 
-fun AppUpdateInfo.isUpdateNeeded(): Boolean =
-    updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
-        isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)
+fun AppUpdateInfo.isUpdateNeeded(): Boolean {
+    return updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE
+}
 
 fun Task<AppUpdateInfo>.addListener(
     onSuccess: (updateInfo: AppUpdateInfo) -> Unit = {},

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/service/KerdyFirebaseMessagingService.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/service/KerdyFirebaseMessagingService.kt
@@ -1,6 +1,7 @@
 package com.emmsale.presentation.service
 
 import android.content.Intent
+import android.net.Uri
 import com.emmsale.R
 import com.emmsale.data.common.retrofit.callAdapter.Failure
 import com.emmsale.data.common.retrofit.callAdapter.NetworkError
@@ -9,11 +10,16 @@ import com.emmsale.data.common.retrofit.callAdapter.Unexpected
 import com.emmsale.data.repository.interfaces.CommentRepository
 import com.emmsale.data.repository.interfaces.ConfigRepository
 import com.emmsale.data.repository.interfaces.TokenRepository
+import com.emmsale.presentation.common.extension.addListener
+import com.emmsale.presentation.common.extension.isUpdateNeeded
 import com.emmsale.presentation.common.extension.showNotification
+import com.emmsale.presentation.common.extension.showToast
 import com.emmsale.presentation.common.extension.topActivityName
 import com.emmsale.presentation.ui.childCommentList.ChildCommentActivity
 import com.emmsale.presentation.ui.eventDetail.EventDetailActivity
 import com.emmsale.presentation.ui.messageList.MessageListActivity
+import com.emmsale.presentation.ui.splash.SplashActivity
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import dagger.hilt.android.AndroidEntryPoint
@@ -34,27 +40,64 @@ class KerdyFirebaseMessagingService : FirebaseMessagingService() {
 
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
+        checkAppUpdate(message)
+    }
 
+    private fun checkAppUpdate(message: RemoteMessage) {
+        val appUpdateManager = AppUpdateManagerFactory.create(this)
+
+        appUpdateManager.appUpdateInfo.addListener(
+            onSuccess = { updateInfo -> showNotification(message, updateInfo.isUpdateNeeded()) },
+            onFailed = {
+                showToast(R.string.splash_not_installed_playstore)
+                navigateToPlayStore()
+            },
+        )
+    }
+
+    private fun showNotification(message: RemoteMessage, isUpdateNeeded: Boolean) {
         val config = configRepository.getConfig()
         val isNotificationReceive = config.isNotificationReceive
         if (!isNotificationReceive || tokenRepository.getToken() == null) return
 
         when (message.data["notificationType"]?.uppercase()) {
             CHILD_COMMENT_NOTIFICATION_TYPE -> {
-                if (config.isCommentNotificationReceive) showChildCommentNotification(message)
+                if (config.isCommentNotificationReceive) {
+                    showChildCommentNotification(
+                        message,
+                        isUpdateNeeded,
+                    )
+                }
             }
 
             EVENT_NOTIFICATION_TYPE -> {
-                if (config.isInterestEventNotificationReceive) showInterestEventNotification(message)
+                if (config.isInterestEventNotificationReceive) {
+                    showInterestEventNotification(
+                        message,
+                        isUpdateNeeded,
+                    )
+                }
             }
 
             MESSAGE_NOTIFICATION_TYPE -> {
-                if (config.isMessageNotificationReceive) showMessageNotification(message)
+                if (config.isMessageNotificationReceive) {
+                    showMessageNotification(
+                        message,
+                        isUpdateNeeded,
+                    )
+                }
             }
         }
     }
 
-    private fun showChildCommentNotification(message: RemoteMessage) {
+    private fun navigateToPlayStore() {
+        val intent = Intent(Intent.ACTION_VIEW)
+            .addCategory(Intent.CATEGORY_BROWSABLE)
+            .setData(Uri.parse("https://play.google.com/store/apps/details?id=$packageName"))
+        startActivity(intent)
+    }
+
+    private fun showChildCommentNotification(message: RemoteMessage, isUpdateNeeded: Boolean) {
         fun getFeedIdAndParentCommentId(commentId: Long): Pair<Long, Long> {
             return runBlocking {
                 when (val result = commentRepository.getComment(commentId)) {
@@ -73,6 +116,12 @@ class KerdyFirebaseMessagingService : FirebaseMessagingService() {
         val (feedId, parentCommentId) = getFeedIdAndParentCommentId(childCommentId)
         if (feedId == ERROR_FEED_ID) return
 
+        val intent = if (isUpdateNeeded) {
+            SplashActivity.getIntent(this)
+        } else {
+            ChildCommentActivity.getIntent(this, feedId, parentCommentId, true)
+        }
+
         baseContext.showNotification(
             title = getString(R.string.kerdyfirebasemessaging_child_comment_notification_title),
             message = getString(R.string.kerdyfirebasemessaging_child_comment_notification_content_format).format(
@@ -80,30 +129,42 @@ class KerdyFirebaseMessagingService : FirebaseMessagingService() {
                 content,
             ),
             channelId = R.id.id_all_child_comment_notification_channel,
-            intent = ChildCommentActivity.getIntent(this, feedId, parentCommentId, true),
+            intent = intent,
             largeIconUrl = writerImageUrl,
         )
     }
 
-    private fun showInterestEventNotification(message: RemoteMessage) {
+    private fun showInterestEventNotification(message: RemoteMessage, isUpdateNeeded: Boolean) {
         val eventId = message.data["redirectId"]?.toLong() ?: return
         val title = message.data["title"] ?: return
+
+        val intent = if (isUpdateNeeded) {
+            SplashActivity.getIntent(this)
+        } else {
+            EventDetailActivity.getIntent(this, eventId)
+        }
 
         baseContext.showNotification(
             title = getString(R.string.kerdyfirebasemessaging_interest_event_notification_title_format),
             message = title,
             channelId = R.id.id_all_interest_event_notification_channel,
-            intent = EventDetailActivity.getIntent(this, eventId),
+            intent = intent,
         )
     }
 
-    private fun showMessageNotification(message: RemoteMessage) {
+    private fun showMessageNotification(message: RemoteMessage, isUpdateNeeded: Boolean) {
         val roomId: String = message.data["roomId"] ?: return
         val senderId = message.data["senderId"]?.toLong() ?: return
 
         val senderProfileUrl = message.data["senderImageUrl"]
         val senderName = message.data["senderName"] ?: return
         val content = message.data["content"] ?: return
+
+        val intent = if (isUpdateNeeded) {
+            SplashActivity.getIntent(this)
+        } else {
+            MessageListActivity.getIntent(this, roomId, senderId)
+        }
 
         if (topActivityName == MessageListActivity::class.java.name) {
             val messageIntent = MessageListActivity
@@ -125,7 +186,7 @@ class KerdyFirebaseMessagingService : FirebaseMessagingService() {
             message = content,
             notificationId = roomId.hashCode(),
             channelId = R.id.id_all_message_notification_channel,
-            intent = MessageListActivity.getIntent(this, roomId, senderId),
+            intent = intent,
             largeIconUrl = senderProfileUrl,
             groupKey = roomId,
         )

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/splash/SplashActivity.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/splash/SplashActivity.kt
@@ -2,6 +2,7 @@ package com.emmsale.presentation.ui.splash
 
 import android.animation.ObjectAnimator
 import android.annotation.SuppressLint
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
@@ -121,5 +122,12 @@ class SplashActivity : ComponentActivity() {
     private fun navigateToLoginScreen() {
         LoginActivity.startActivity(this)
         finish()
+    }
+
+    companion object {
+        fun getIntent(context: Context): Intent = Intent(
+            context,
+            SplashActivity::class.java,
+        ).addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close : #765

## 📝 작업 내용
- FCM 푸시 알림을 클릭했을 때 업데이트가 필요하면 스플래시 화면으로 이동하도록 하였습니다.
- FCM Service는 일반 서비스와 다르게 onMessageReceived()가 Background에서 수행됩니다.
- 반대로 앱 버전 체크는 Main에서 실행됩니다.
- 이러한 문제로 앱 버전에서 singleThreadCoroutine을 사용하여 백그라운드에서 처리되도록 하였습니다. (노티피케이션 순서 문제를 방지하고자 싱글 스레드를 사용합니다.)
- 버전 코드를 54로 변경하였고, 버그 수정이 있었기 때문에 2.1.1v로 변경하였습니다.

### 스크린샷 (선택)
<img width="258" alt="스크린샷 2023-10-20 오전 1 46 55" src="https://github.com/woowacourse-teams/2023-emmsale/assets/56534241/2d5068c7-5318-4104-93d3-94a52e7b8521">

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)
예상 소요 시간 : 30분
실제 소요 시간 : 1시간 30분

## 💬 리뷰어 요구사항 (선택)
QA는 함께 마친 상태이므로 코드 리뷰만 부탁드립니다.

