### PR TITLE
Feature/#776 행사 화면 새로고침 기능

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/competitionList/CompetitionViewModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/competitionList/CompetitionViewModel.kt
@@ -38,12 +38,12 @@ class CompetitionViewModel @Inject constructor(
     val selectedFilter: NotNullLiveData<CompetitionSelectedFilteringUiState> = _selectedFilter
 
     init {
+        _selectedFilter.value = CompetitionSelectedFilteringUiState()
         refresh()
     }
 
     override fun refresh() {
-        _selectedFilter.value = CompetitionSelectedFilteringUiState()
-        fetchCompetitions()
+        fetchFilteredCompetitions()
     }
 
     private fun fetchCompetitions(

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/competitionList/CompetitionViewModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/competitionList/CompetitionViewModel.kt
@@ -38,7 +38,6 @@ class CompetitionViewModel @Inject constructor(
     val selectedFilter: NotNullLiveData<CompetitionSelectedFilteringUiState> = _selectedFilter
 
     init {
-        _selectedFilter.value = CompetitionSelectedFilteringUiState()
         refresh()
     }
 

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/conferenceList/ConferenceFragment.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/conferenceList/ConferenceFragment.kt
@@ -24,9 +24,7 @@ import java.time.LocalDate
 class ConferenceFragment : BaseFragment<FragmentConferenceBinding>() {
     override val layoutResId: Int = R.layout.fragment_conference
     private val viewModel: ConferenceViewModel by viewModels()
-    private val eventAdapter: ConferenceRecyclerViewAdapter by lazy {
-        ConferenceRecyclerViewAdapter(::navigateToEventDetail)
-    }
+    private val eventAdapter by lazy { ConferenceRecyclerViewAdapter(::navigateToEventDetail) }
     private val filterActivityLauncher =
         registerForActivityResult(StartActivityForResult()) { result ->
             if (result == null || result.resultCode != RESULT_OK) return@registerForActivityResult

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/conferenceList/ConferenceViewModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/conferenceList/ConferenceViewModel.kt
@@ -38,7 +38,6 @@ class ConferenceViewModel @Inject constructor(
     val selectedFilter: NotNullLiveData<ConferenceSelectedFilteringUiState> = _selectedFilter
 
     init {
-        _selectedFilter.value = ConferenceSelectedFilteringUiState()
         refresh()
     }
 

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/conferenceList/ConferenceViewModel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/conferenceList/ConferenceViewModel.kt
@@ -38,12 +38,12 @@ class ConferenceViewModel @Inject constructor(
     val selectedFilter: NotNullLiveData<ConferenceSelectedFilteringUiState> = _selectedFilter
 
     init {
+        _selectedFilter.value = ConferenceSelectedFilteringUiState()
         refresh()
     }
 
     override fun refresh() {
-        _selectedFilter.value = ConferenceSelectedFilteringUiState()
-        fetchConferences()
+        fetchFilteredConferences()
     }
 
     private fun fetchConferences(

--- a/android/2023-emmsale/app/src/main/res/layout/fragment_competition.xml
+++ b/android/2023-emmsale/app/src/main/res/layout/fragment_competition.xml
@@ -13,128 +13,135 @@
             type="com.emmsale.presentation.ui.competitionList.CompetitionViewModel" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        onRefresh="@{() -> viewModel.refresh()}"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:background="@color/white"
-        tools:context=".presentation.ui.competitionFilter.CompetitionFilterActivity">
+        app:swipeRefreshColor="@{@color/primary_color}">
 
-        <TextView
-            android:id="@+id/tv_events_prefix"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="17dp"
-            android:layout_marginTop="@dimen/event_count_text_margin_top"
-            android:text="@string/event_count_prefix"
-            android:textColor="@color/black"
-            android:textSize="12sp"
-            android:textStyle="bold"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-            android:id="@+id/tv_events_count"
-            android:layout_width="wrap_content"
-            android:layout_height="0dp"
-            android:layout_marginStart="6dp"
-            android:gravity="center"
-            android:text="@{@string/event_count_format(viewModel.competitions.competitionSize)}"
-            android:textColor="@color/primary_color"
-            android:textSize="12sp"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="@+id/tv_events_prefix"
-            app:layout_constraintStart_toEndOf="@+id/tv_events_prefix"
-            app:layout_constraintTop_toTopOf="@+id/tv_events_prefix"
-            tools:text="58" />
-
-        <LinearLayout
-            android:id="@+id/btn_event_filter"
-            android:layout_width="wrap_content"
-            android:layout_height="0dp"
-            android:layout_marginEnd="17dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:clickable="true"
-            android:focusable="true"
-            android:orientation="horizontal"
-            app:layout_constraintBottom_toBottomOf="@+id/tv_events_prefix"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@+id/tv_events_prefix">
-
-            <ImageView
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:layout_marginEnd="2dp"
-                android:contentDescription="@string/event_filter"
-                android:src="@drawable/ic_event_filter" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            tools:background="@color/white"
+            tools:context=".presentation.ui.competitionFilter.CompetitionFilterActivity">
 
             <TextView
-                android:id="@+id/tv_filter"
+                android:id="@+id/tv_events_prefix"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/event_filter"
+                android:layout_marginStart="17dp"
+                android:layout_marginTop="@dimen/event_count_text_margin_top"
+                android:text="@string/event_count_prefix"
                 android:textColor="@color/black"
                 android:textSize="12sp"
+                android:textStyle="bold"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-        </LinearLayout>
-
-        <HorizontalScrollView
-            android:id="@+id/sv_filters"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="15dp"
-            android:clipToPadding="false"
-            android:overScrollMode="never"
-            android:paddingHorizontal="17dp"
-            android:scrollbars="none"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/btn_event_filter"
-            app:visible="@{viewModel.selectedFilter.isShowFilter}">
+            <TextView
+                android:id="@+id/tv_events_count"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:layout_marginStart="6dp"
+                android:gravity="center"
+                android:text="@{@string/event_count_format(viewModel.competitions.competitionSize)}"
+                android:textColor="@color/primary_color"
+                android:textSize="12sp"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="@+id/tv_events_prefix"
+                app:layout_constraintStart_toEndOf="@+id/tv_events_prefix"
+                app:layout_constraintTop_toTopOf="@+id/tv_events_prefix"
+                tools:text="58" />
 
             <LinearLayout
-                android:id="@+id/layout_competition_filters"
+                android:id="@+id/btn_event_filter"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:layout_marginEnd="17dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:clickable="true"
+                android:focusable="true"
+                android:orientation="horizontal"
+                app:layout_constraintBottom_toBottomOf="@+id/tv_events_prefix"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/tv_events_prefix">
+
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:layout_marginEnd="2dp"
+                    android:contentDescription="@string/event_filter"
+                    android:src="@drawable/ic_event_filter" />
+
+                <TextView
+                    android:id="@+id/tv_filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/event_filter"
+                    android:textColor="@color/black"
+                    android:textSize="12sp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+            </LinearLayout>
+
+            <HorizontalScrollView
+                android:id="@+id/sv_filters"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="15dp"
+                android:clipToPadding="false"
+                android:overScrollMode="never"
+                android:paddingHorizontal="17dp"
+                android:scrollbars="none"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/btn_event_filter"
+                app:visible="@{viewModel.selectedFilter.isShowFilter}">
+
+                <LinearLayout
+                    android:id="@+id/layout_competition_filters"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal" />
+
+            </HorizontalScrollView>
+
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_events"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginTop="7dp"
+                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/sv_filters"
+                app:spanCount="@integer/event_column_size"
+                tools:itemCount="5"
+                tools:listitem="@layout/item_competition" />
+
+            <ProgressBar
+                android:id="@+id/progressbar_loading"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal" />
+                android:indeterminate="true"
+                android:visibility="@{viewModel.competitions.loading ? View.VISIBLE : View.GONE}"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:visibility="gone" />
 
-        </HorizontalScrollView>
+            <include
+                layout="@layout/layout_all_error_screen"
+                android:background="@color/white"
+                android:clickable="true"
+                android:visibility="@{viewModel.competitions.isError ? View.VISIBLE : View.GONE}"
+                bind:viewModel="@{viewModel}"
+                tools:visibility="gone" />
 
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rv_events"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_marginTop="7dp"
-            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/sv_filters"
-            app:spanCount="@integer/event_column_size"
-            tools:itemCount="5"
-            tools:listitem="@layout/item_competition" />
-
-        <ProgressBar
-            android:id="@+id/progressbar_loading"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:indeterminate="true"
-            android:visibility="@{viewModel.competitions.loading ? View.VISIBLE : View.GONE}"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:visibility="gone" />
-
-        <include
-            layout="@layout/layout_all_error_screen"
-            android:background="@color/white"
-            android:clickable="true"
-            android:visibility="@{viewModel.competitions.isError ? View.VISIBLE : View.GONE}"
-            bind:viewModel="@{viewModel}"
-            tools:visibility="gone" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 </layout>

--- a/android/2023-emmsale/app/src/main/res/layout/fragment_competition.xml
+++ b/android/2023-emmsale/app/src/main/res/layout/fragment_competition.xml
@@ -22,7 +22,6 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            tools:background="@color/white"
             tools:context=".presentation.ui.competitionFilter.CompetitionFilterActivity">
 
             <TextView

--- a/android/2023-emmsale/app/src/main/res/layout/fragment_conference.xml
+++ b/android/2023-emmsale/app/src/main/res/layout/fragment_conference.xml
@@ -13,127 +13,134 @@
             type="com.emmsale.presentation.ui.conferenceList.ConferenceViewModel" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        onRefresh="@{() -> viewModel.refresh()}"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".presentation.ui.conferenceList.ConferenceFragment">
+        app:swipeRefreshColor="@{@color/primary_color}">
 
-        <TextView
-            android:id="@+id/tv_events_prefix"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="17dp"
-            android:layout_marginTop="@dimen/event_count_text_margin_top"
-            android:text="@string/event_count_prefix"
-            android:textColor="@color/black"
-            android:textSize="12sp"
-            android:textStyle="bold"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-            android:id="@+id/tv_events_count"
-            android:layout_width="wrap_content"
-            android:layout_height="0dp"
-            android:layout_marginStart="6dp"
-            android:gravity="center"
-            android:text="@{@string/event_count_format(viewModel.conferences.conferenceSize)}"
-            android:textColor="@color/primary_color"
-            android:textSize="12sp"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="@+id/tv_events_prefix"
-            app:layout_constraintStart_toEndOf="@+id/tv_events_prefix"
-            app:layout_constraintTop_toTopOf="@+id/tv_events_prefix"
-            tools:text="58" />
-
-        <LinearLayout
-            android:id="@+id/btn_event_filter"
-            android:layout_width="wrap_content"
-            android:layout_height="0dp"
-            android:layout_marginEnd="17dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:clickable="true"
-            android:focusable="true"
-            android:orientation="horizontal"
-            app:layout_constraintBottom_toBottomOf="@+id/tv_events_prefix"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@+id/tv_events_prefix">
-
-            <ImageView
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:layout_marginEnd="2dp"
-                android:contentDescription="@string/event_filter"
-                android:src="@drawable/ic_event_filter" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            tools:context=".presentation.ui.conferenceList.ConferenceFragment">
 
             <TextView
-                android:id="@+id/tv_filter"
+                android:id="@+id/tv_events_prefix"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/event_filter"
+                android:layout_marginStart="17dp"
+                android:layout_marginTop="@dimen/event_count_text_margin_top"
+                android:text="@string/event_count_prefix"
                 android:textColor="@color/black"
                 android:textSize="12sp"
+                android:textStyle="bold"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-        </LinearLayout>
-
-        <HorizontalScrollView
-            android:id="@+id/sv_filters"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="15dp"
-            android:clipToPadding="false"
-            android:overScrollMode="never"
-            android:paddingHorizontal="17dp"
-            android:scrollbars="none"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/btn_event_filter"
-            app:visible="@{viewModel.selectedFilter.isShowFilter}">
+            <TextView
+                android:id="@+id/tv_events_count"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:layout_marginStart="6dp"
+                android:gravity="center"
+                android:text="@{@string/event_count_format(viewModel.conferences.conferenceSize)}"
+                android:textColor="@color/primary_color"
+                android:textSize="12sp"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="@+id/tv_events_prefix"
+                app:layout_constraintStart_toEndOf="@+id/tv_events_prefix"
+                app:layout_constraintTop_toTopOf="@+id/tv_events_prefix"
+                tools:text="58" />
 
             <LinearLayout
-                android:id="@+id/layout_conference_filters"
+                android:id="@+id/btn_event_filter"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:layout_marginEnd="17dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:clickable="true"
+                android:focusable="true"
+                android:orientation="horizontal"
+                app:layout_constraintBottom_toBottomOf="@+id/tv_events_prefix"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/tv_events_prefix">
+
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:layout_marginEnd="2dp"
+                    android:contentDescription="@string/event_filter"
+                    android:src="@drawable/ic_event_filter" />
+
+                <TextView
+                    android:id="@+id/tv_filter"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/event_filter"
+                    android:textColor="@color/black"
+                    android:textSize="12sp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+            </LinearLayout>
+
+            <HorizontalScrollView
+                android:id="@+id/sv_filters"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="15dp"
+                android:clipToPadding="false"
+                android:overScrollMode="never"
+                android:paddingHorizontal="17dp"
+                android:scrollbars="none"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/btn_event_filter"
+                app:visible="@{viewModel.selectedFilter.isShowFilter}">
+
+                <LinearLayout
+                    android:id="@+id/layout_conference_filters"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal" />
+
+            </HorizontalScrollView>
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_events"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginTop="6dp"
+                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/sv_filters"
+                app:spanCount="@integer/event_column_size"
+                tools:itemCount="5"
+                tools:listitem="@layout/item_conference" />
+
+            <ProgressBar
+                android:id="@+id/progressbar_loading"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal" />
+                android:indeterminate="true"
+                android:visibility="@{viewModel.conferences.loading ? View.VISIBLE : View.GONE}"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintDimensionRatio="0.15"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:visibility="gone" />
 
-        </HorizontalScrollView>
+            <include
+                layout="@layout/layout_all_error_screen"
+                android:background="@color/white"
+                android:clickable="true"
+                android:visibility="@{viewModel.conferences.isError ? View.VISIBLE : View.GONE}"
+                bind:viewModel="@{viewModel}"
+                tools:visibility="gone" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rv_events"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_marginTop="6dp"
-            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/sv_filters"
-            app:spanCount="@integer/event_column_size"
-            tools:itemCount="5"
-            tools:listitem="@layout/item_conference" />
-
-        <ProgressBar
-            android:id="@+id/progressbar_loading"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:indeterminate="true"
-            android:visibility="@{viewModel.conferences.loading ? View.VISIBLE : View.GONE}"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintDimensionRatio="0.15"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:visibility="gone" />
-
-        <include
-            layout="@layout/layout_all_error_screen"
-            android:background="@color/white"
-            android:clickable="true"
-            android:visibility="@{viewModel.conferences.isError ? View.VISIBLE : View.GONE}"
-            bind:viewModel="@{viewModel}"
-            tools:visibility="gone" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 </layout>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close : #776 

## 📝 작업 내용

### 스크린샷 (선택)
<img width="339" alt="스크린샷 2023-10-23 오후 3 46 30" src="https://github.com/woowacourse-teams/2023-emmsale/assets/56534241/60ea7792-ef59-42a3-a610-33e2c3bb8de3">

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)
예상 소요 시간 : 30분
실제 소요 시간 : 30분

## 💬 리뷰어 요구사항 (선택)
SwipeRefreshLayout을 통해 새로고침을 구현하였습니다.
`Conference / CompetitionViewModel` 을 확인해보니, 필터 태그를 통해 불러오는 함수와, 태그 없이 불러오는 함수가 각각 존재합니다.
별도의 이슈라고 생각해서 해당 PR에서는 작업하지 않았고, 리팩터링시 개선이 필요해보입니다.



