### PR TITLE
Feature/#784 채팅 화면이 맨 밑으로 내려가지 않는 버그

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageList/MessageListActivity.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageList/MessageListActivity.kt
@@ -60,6 +60,11 @@ class MessageListActivity : AppCompatActivity() {
         binding.rvMessageList.setHasFixedSize(true)
         binding.rvMessageList.itemAnimator = null
         binding.rvMessageList.adapter = messageListAdapter
+        binding.rvMessageList.setOnScrollChangeListener { v, _, _, _, _ ->
+            if (!v.canScrollVertically(BOTTOM_SCROLL_DIRECTION)) {
+                hideBottomMessage()
+            }
+        }
     }
 
     private fun navigateToProfile(uid: Long) {
@@ -148,6 +153,7 @@ class MessageListActivity : AppCompatActivity() {
     }
 
     companion object {
+        private const val BOTTOM_SCROLL_DIRECTION = 1
         private const val KEY_PROFILE_URL = "KEY_PROFILE_URL"
         private const val KEY_OTHER_NAME = "KEY_OTHER_NAME"
         private const val KEY_MESSAGE_CONTENT = "KEY_MESSAGE_CONTENT"

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageList/MessageListActivity.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageList/MessageListActivity.kt
@@ -124,7 +124,9 @@ class MessageListActivity : AppCompatActivity() {
         val layoutManager = binding.rvMessageList.layoutManager as LinearLayoutManager
         val lastVisiblePos = layoutManager.findLastVisibleItemPosition()
         val itemCount = viewModel.messages.value.messages.size
-        if (lastVisiblePos <= itemCount - 3) {
+        val lastPosition = itemCount - 1
+
+        if (lastVisiblePos != lastPosition) {
             job?.cancel()
             job = lifecycleScope.launch {
                 showBottomMessage(profileUrl, otherName, messageContent)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close : #784

## 📝 작업 내용
- 채팅 화면이 맨 밑으로 내려가는 버그가 있었습니다.
그래서 채팅이 맨 마지막이 아닌 이상, 상대방이 채팅을 보내는 경우 항상 `채팅 미리보기` 를 제공하도록 하였습니다.
자신이 채팅을 보내면 가장 하단으로 이동하는 것은 기존과 동일합니다.

- 채팅방 최하단으로 내려가도 채팅 미리보기가 지워지지 않는 문제가 있어서 함께 해결하였습니다.

### 스크린샷 (선택)
<img width='40%' src='https://github.com/woowacourse-teams/2023-emmsale/assets/56534241/c47a7b3e-d864-47ce-a7cf-45b9d62e5f16'>

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)
예상 소요 시간 : -
실제 소요 시간 : 30분

## 💬 리뷰어 요구사항 (선택)
구동 영상은 GIF를 확인해주세요~ 🎥


