### PR TITLE
Fix/#816 알림 태그 수정 버그

### DIFF
--- a/android/2023-emmsale/app/build.gradle.kts
+++ b/android/2023-emmsale/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.emmsale"
         minSdk = 28
         targetSdk = 33
-        versionCode = 55
-        versionName = "2.1.2"
+        versionCode = 56
+        versionName = "2.1.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/apiModel/response/EventTagResponse.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/apiModel/response/EventTagResponse.kt
@@ -10,11 +10,3 @@ data class EventTagResponse(
     @SerialName("name")
     val name: String,
 )
-
-@Serializable
-data class UpdatedMemberInterestEventTagResponse(
-    @SerialName("id")
-    val id: Long,
-    @SerialName("name")
-    val name: String,
-)

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/dataSource/remote/EventTagRemoteDataSource.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/dataSource/remote/EventTagRemoteDataSource.kt
@@ -2,7 +2,6 @@ package com.emmsale.data.dataSource.remote
 
 import com.emmsale.data.apiModel.request.InterestEventTagUpdateRequest
 import com.emmsale.data.apiModel.response.EventTagResponse
-import com.emmsale.data.apiModel.response.UpdatedMemberInterestEventTagResponse
 import com.emmsale.data.common.retrofit.callAdapter.ApiResponse
 import com.emmsale.data.service.EventTagService
 import javax.inject.Inject
@@ -22,7 +21,7 @@ class EventTagRemoteDataSource @Inject constructor(
 
     suspend fun updateInterestEventTags(
         requestModel: InterestEventTagUpdateRequest,
-    ): ApiResponse<List<UpdatedMemberInterestEventTagResponse>> {
+    ): ApiResponse<Unit> {
         return eventTagService.updateInterestEventTags(requestModel)
     }
 }

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/service/EventTagService.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/service/EventTagService.kt
@@ -2,7 +2,6 @@ package com.emmsale.data.service
 
 import com.emmsale.data.apiModel.request.InterestEventTagUpdateRequest
 import com.emmsale.data.apiModel.response.EventTagResponse
-import com.emmsale.data.apiModel.response.UpdatedMemberInterestEventTagResponse
 import com.emmsale.data.common.retrofit.callAdapter.ApiResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -21,5 +20,5 @@ interface EventTagService {
     @PUT("/interest-tags")
     suspend fun updateInterestEventTags(
         @Body requestModel: InterestEventTagUpdateRequest,
-    ): ApiResponse<List<UpdatedMemberInterestEventTagResponse>>
+    ): ApiResponse<Unit>
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close : #816

## 📝 작업 내용

`EventTagResponse` 클래스와 완전히 동일한 `UpdatedMemberInterestEventTagResponse` 클래스를 제거하여 최적화 시 클래스가 사라짐으로 인해 앱이 터지는 문제 해결

### 스크린샷 (선택)

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)
예상 소요 시간 : 1분
실제 소요 시간 : 1분

## 💬 리뷰어 요구사항 (선택)

간단하므로 바로 머지하겠습니다.



