### PR TITLE
Feature/#786 푸시 알림으로 채팅 화면에 들어가면 뒤로가기를 했을 때 홈 화면으로 이동

### DIFF
--- a/android/2023-emmsale/app/src/main/AndroidManifest.xml
+++ b/android/2023-emmsale/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
         <activity
             android:name=".presentation.ui.messageList.MessageListActivity"
             android:launchMode="singleTask"
+            android:parentActivityName=".presentation.ui.main.MainActivity"
             android:windowSoftInputMode="adjustResize" />
         <activity android:name=".presentation.ui.postWriting.PostWritingActivity" />
         <activity

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/KerdyApplication.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/KerdyApplication.kt
@@ -1,7 +1,6 @@
 package com.emmsale.presentation
 
 import android.app.Application
-import android.app.NotificationManager
 import com.emmsale.presentation.common.KerdyNotificationChannel
 import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.HiltAndroidApp
@@ -19,9 +18,7 @@ class KerdyApplication : Application() {
     }
 
     private fun initNotificationChannels() {
-        val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
-        val kerdyNotificationChannels = KerdyNotificationChannel.createChannels(this)
-        notificationManager.createNotificationChannels(kerdyNotificationChannels)
+        KerdyNotificationChannel.createChannels(this)
     }
 
     companion object {

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/KerdyApplication.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/KerdyApplication.kt
@@ -1,15 +1,13 @@
 package com.emmsale.presentation
 
 import android.app.Application
-import android.app.NotificationChannel
 import android.app.NotificationManager
-import com.emmsale.R
+import com.emmsale.presentation.common.KerdyNotificationChannel
 import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
 class KerdyApplication : Application() {
-
     override fun onCreate() {
         super.onCreate()
         initFirebaseAnalytics()
@@ -22,58 +20,8 @@ class KerdyApplication : Application() {
 
     private fun initNotificationChannels() {
         val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
-
-        val notificationChannels = listOf(
-            createChildCommentNotificationChannel(),
-            createInterestEventNotificationChannel(),
-            createMessageNotificationChannel(),
-        )
-        notificationManager.createNotificationChannels(notificationChannels)
-    }
-
-    private fun createChildCommentNotificationChannel(): NotificationChannel {
-        val channelId = R.id.id_all_child_comment_notification_channel
-        val channelName =
-            getString(R.string.kerdyfirebasemessaging_child_comment_notification_channel_name)
-        val channelDescription =
-            getString(R.string.kerdyfirebasemessaging_child_comment_notification_channel_description)
-        return NotificationChannel(
-            channelId.toString(),
-            channelName,
-            NotificationManager.IMPORTANCE_HIGH,
-        ).apply {
-            description = channelDescription
-        }
-    }
-
-    private fun createInterestEventNotificationChannel(): NotificationChannel {
-        val channelId = R.id.id_all_interest_event_notification_channel
-        val channelName =
-            getString(R.string.kerdyfirebasemessaging_interest_event_notification_channel_name)
-        val channelDescription =
-            getString(R.string.kerdyfirebasemessaging_interest_event_notification_channel_description)
-        return NotificationChannel(
-            channelId.toString(),
-            channelName,
-            NotificationManager.IMPORTANCE_HIGH,
-        ).apply {
-            description = channelDescription
-        }
-    }
-
-    private fun createMessageNotificationChannel(): NotificationChannel {
-        val channelId = R.id.id_all_message_notification_channel
-        val channelName =
-            getString(R.string.kerdyfirebasemessaging_message_notification_channel_name)
-        val channelDescription =
-            getString(R.string.kerdyfirebasemessaging_message_notification_channel_description)
-        return NotificationChannel(
-            channelId.toString(),
-            channelName,
-            NotificationManager.IMPORTANCE_HIGH,
-        ).apply {
-            description = channelDescription
-        }
+        val kerdyNotificationChannels = KerdyNotificationChannel.createChannels(this)
+        notificationManager.createNotificationChannels(kerdyNotificationChannels)
     }
 
     companion object {

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/common/KerdyNotificationChannel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/common/KerdyNotificationChannel.kt
@@ -38,10 +38,16 @@ enum class KerdyNotificationChannel(
     }
 
     companion object {
-        fun createChannels(
-            context: Context,
-        ): List<NotificationChannel> = KerdyNotificationChannel
-            .values()
-            .map { channel -> channel.createChannel(context) }
+        private fun getNotificationManager(context: Context): NotificationManager {
+            return context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        }
+
+        fun createChannels(context: Context) {
+            val kerdyNotificationChannels = KerdyNotificationChannel
+                .values()
+                .map { channel -> channel.createChannel(context) }
+
+            getNotificationManager(context).createNotificationChannels(kerdyNotificationChannels)
+        }
     }
 }

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/common/KerdyNotificationChannel.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/common/KerdyNotificationChannel.kt
@@ -1,0 +1,47 @@
+package com.emmsale.presentation.common
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import androidx.annotation.StringRes
+import com.emmsale.R
+
+enum class KerdyNotificationChannel(
+    private val channelId: String,
+    @StringRes private val channelNameResId: Int,
+    @StringRes private val channelDescResId: Int,
+    private val channelImportance: Int = NotificationManager.IMPORTANCE_HIGH,
+) {
+    CHILD_COMMENT(
+        channelId = R.id.id_all_child_comment_notification_channel.toString(),
+        channelNameResId = R.string.kerdyfirebasemessaging_child_comment_notification_channel_name,
+        channelDescResId = R.string.kerdyfirebasemessaging_child_comment_notification_channel_description,
+    ),
+    INTEREST_EVENT(
+        channelId = R.id.id_all_interest_event_notification_channel.toString(),
+        channelNameResId = R.string.kerdyfirebasemessaging_interest_event_notification_channel_name,
+        channelDescResId = R.string.kerdyfirebasemessaging_interest_event_notification_channel_description,
+    ),
+    MESSAGE(
+        channelId = R.id.id_all_message_notification_channel.toString(),
+        channelNameResId = R.string.kerdyfirebasemessaging_message_notification_channel_name,
+        channelDescResId = R.string.kerdyfirebasemessaging_message_notification_channel_description,
+    ),
+    ;
+
+    fun createChannel(context: Context): NotificationChannel = NotificationChannel(
+        channelId,
+        context.getString(channelNameResId),
+        channelImportance,
+    ).apply {
+        description = context.getString(channelDescResId)
+    }
+
+    companion object {
+        fun createChannels(
+            context: Context,
+        ): List<NotificationChannel> = KerdyNotificationChannel
+            .values()
+            .map { channel -> channel.createChannel(context) }
+    }
+}

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/common/extension/ContextExt.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/common/extension/ContextExt.kt
@@ -16,6 +16,7 @@ import androidx.annotation.StringRes
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.TaskStackBuilder
 import androidx.core.content.ContextCompat
 import com.emmsale.R
 import com.emmsale.presentation.common.views.ConfirmDialog
@@ -113,7 +114,7 @@ private fun Context.createNotification(
     title: String,
     message: String,
     notificationId: Int,
-    intent: Intent? = null,
+    intent: Intent = Intent(),
     largeIconUrl: String? = null,
     groupKey: String? = null,
 ) = NotificationCompat.Builder(this, channelId.toString())
@@ -124,11 +125,20 @@ private fun Context.createNotification(
     .setGroupSummary(true)
     .setGroup(groupKey)
     .setContentText(message)
-    .setContentIntent(
-        PendingIntent.getActivity(this, notificationId, intent, PendingIntent.FLAG_MUTABLE),
-    )
+    .setContentIntent(getPendingIntent(intent, notificationId))
     .setAutoCancel(true)
     .build()
+
+private fun Context.getPendingIntent(
+    intent: Intent,
+    notificationId: Int,
+): PendingIntent? = TaskStackBuilder.create(this).run {
+    addNextIntentWithParentStack(intent)
+    getPendingIntent(
+        notificationId,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+    )
+}
 
 val Context.topActivityName: String?
     get() {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close : #786

## 📝 작업 내용
- 푸시 알림으로 앱에 진입했을 때, 뒤로가기를 하면 앱이 종료되지 않고 홈 화면으로 이동하게끔 하였습니다.
- 기존에 NotificationChannel을 생성하는 코드가 `보일러 플레이트` 라고 생각하여 개선을 해보았습니다.
  + `KerdyNotificationChannel` 클래스를 만들어 채널 생성을 관리합니다.
  + 가능한 OCP를 준수하도록 변경하였습니다. 
     - 채널이 추가되어도 KerdyNotificationChannel 의 상수만 추가하면 되므로 유지보수성 🆙

### 스크린샷 (선택)

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)
예상 소요 시간 : 2시간
실제 소요 시간 : 1시간

## 💬 리뷰어 요구사항 (선택)


