### PR TITLE
feat: 응답 코드가 401이면 로그인 화면으로 이동하는 기능 구현

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/retrofit/AuthInterceptor.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/retrofit/AuthInterceptor.kt
@@ -23,7 +23,6 @@ class AuthInterceptor(private val context: Context) : Interceptor {
 
         val response = chain.proceed(tokenAddedRequest)
         if (response.isAccessTokenExpired()) {
-            tokenRepository.deleteToken()
             navigateToLogin()
         }
         return response

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/retrofit/AuthInterceptor.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/retrofit/AuthInterceptor.kt
@@ -1,25 +1,48 @@
 package com.emmsale.data.common.retrofit
 
 import android.content.Context
+import android.content.Intent
 import com.emmsale.data.repository.interfaces.TokenRepository
+import com.emmsale.presentation.ui.login.LoginActivity
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
 import okhttp3.Interceptor
+import okhttp3.Request
 import okhttp3.Response
 
-class AuthInterceptor(context: Context) : Interceptor {
+class AuthInterceptor(private val context: Context) : Interceptor {
     private val tokenRepository = EntryPointAccessors
         .fromApplication<AuthInterceptorEntryPoint>(context)
         .getTokenRepository()
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val token = tokenRepository.getToken()
-        val newRequest = chain.request().newBuilder()
-            .addHeader(ACCESS_TOKEN_HEADER, ACCESS_TOKEN_FORMAT.format(token?.accessToken))
-            .build()
-        return chain.proceed(newRequest)
+        val tokenAddedRequest = chain.request().putAccessToken(token?.accessToken)
+
+        val response = chain.proceed(tokenAddedRequest)
+        if (response.isAccessTokenExpired()) {
+            tokenRepository.deleteToken()
+            navigateToLogin()
+        }
+        return response
+    }
+
+    private fun Response.isAccessTokenExpired(): Boolean = (code == 401)
+
+    private fun Request.putAccessToken(token: String?): Request =
+        putHeader(ACCESS_TOKEN_HEADER, ACCESS_TOKEN_FORMAT.format(token))
+
+    private fun Request.putHeader(
+        key: String,
+        value: String,
+    ): Request = newBuilder().addHeader(key, value).build()
+
+    private fun navigateToLogin() {
+        val loginStartIntent = Intent(context, LoginActivity::class.java)
+            .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+        context.startActivity(loginStartIntent)
     }
 
     @EntryPoint

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/retrofit/AuthInterceptor.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/data/common/retrofit/AuthInterceptor.kt
@@ -22,13 +22,13 @@ class AuthInterceptor(private val context: Context) : Interceptor {
         val tokenAddedRequest = chain.request().putAccessToken(token?.accessToken)
 
         val response = chain.proceed(tokenAddedRequest)
-        if (response.isAccessTokenExpired()) {
+        if (response.isAccessTokenInvalid()) {
             navigateToLogin()
         }
         return response
     }
 
-    private fun Response.isAccessTokenExpired(): Boolean = (code == 401)
+    private fun Response.isAccessTokenInvalid(): Boolean = (code == 401)
 
     private fun Request.putAccessToken(token: String?): Request =
         putHeader(ACCESS_TOKEN_HEADER, ACCESS_TOKEN_FORMAT.format(token))


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close : #830

## 📝 작업 내용
response code가 `401` 이면 로그인 화면으로 이동하도록 구현하였습니다.

### 스크린샷 (선택)

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)
예상 소요 시간 : 1시간
실제 소요 시간 : 30분

## 💬 리뷰어 요구사항 (선택)
**테스트 권장 방법**
- `Response.isAccessTokenExpired()` 의 반환을 true로 설정하면 토큰이 만료되었을 때 상황을 가정할 수 있습니다.

**Refresh Token 도입된다면?**
- RefreshToken으로 AccessToken을 재발급받습니다.
- 새롭게 발급받은 AccessToken으로 Interceptor에 새롭게 토큰을 추가하여 재요청합니다.

**듣고 싶은 의견** 
- RefreshToken이 만료된다면 로그인 화면으로 이동해야 합니다.
- 그렇다면, RefreshToken이 만료된 사실은 어떻게 알 수 있을까요?



