### PR TITLE
fix : 피드 목록이 나왔다가 바로 사라지는 버그 수정

### DIFF
--- a/android/2023-emmsale/app/build.gradle.kts
+++ b/android/2023-emmsale/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.emmsale"
         minSdk = 28
         targetSdk = 33
-        versionCode = 57
-        versionName = "2.1.4"
+        versionCode = 58
+        versionName = "2.1.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/android/2023-emmsale/app/src/main/res/layout/activity_event_detail.xml
+++ b/android/2023-emmsale/app/src/main/res/layout/activity_event_detail.xml
@@ -192,7 +192,7 @@
         <androidx.viewpager2.widget.ViewPager2
             android:id="@+id/vp_eventdetail"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
         <androidx.constraintlayout.widget.ConstraintLayout


### PR DESCRIPTION
- viewPager의 height 를 match_parent로 수정

## #️⃣ 연관된 이슈
> close : #837

## 📝 작업 내용
- ViewPager의 height를 wrap_content에서 match_parent로 바꿔서 오류를 해결했습니다.

### 스크린샷 (선택)
[행사목록버그.webm](https://github.com/woowacourse-teams/2023-emmsale/assets/76036731/c6d26f02-7e5f-402f-8948-65f56233c348)


## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)
예상 소요 시간 : 5분
실제 소요 시간 : 5분

## 💬 리뷰어 요구사항 (선택)



