### PR TITLE
Fix/#840 member acitivity id 반환값 변경

### DIFF
--- a/backend/emm-sale/src/documentTest/java/com/emmsale/MemberApiTest.java
+++ b/backend/emm-sale/src/documentTest/java/com/emmsale/MemberApiTest.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.emmsale.activity.application.dto.ActivityResponse;
 import com.emmsale.member.api.MemberApi;
 import com.emmsale.member.application.dto.DescriptionRequest;
 import com.emmsale.member.application.dto.MemberActivityAddRequest;
@@ -95,10 +96,10 @@ class MemberApiTest extends MockMvcTestHelper {
     final List<Long> activityIds = List.of(4L, 5L, 6L);
     final MemberActivityAddRequest request = new MemberActivityAddRequest(activityIds);
 
-    final List<MemberActivityResponse> memberActivityResponses = createMemberActivityResponses();
+    final List<ActivityResponse> activityResponses = createActivityResponses();
 
     when(memberActivityCommandService.addActivity(any(), any()))
-        .thenReturn(memberActivityResponses);
+        .thenReturn(activityResponses);
 
     //when & then
     mockMvc.perform(post("/members/activities")
@@ -111,14 +112,14 @@ class MemberApiTest extends MockMvcTestHelper {
             MEMBER_ACTIVITY_RESPONSE_FIELDS));
   }
 
-  private List<MemberActivityResponse> createMemberActivityResponses() {
+  private List<ActivityResponse> createActivityResponses() {
     return List.of(
-        new MemberActivityResponse(1L, "YAPP", "동아리"),
-        new MemberActivityResponse(2L, "DND", "동아리"),
-        new MemberActivityResponse(3L, "nexters", "동아리"),
-        new MemberActivityResponse(4L, "인프콘", "컨퍼런스"),
-        new MemberActivityResponse(5L, "우아한테크코스", "교육"),
-        new MemberActivityResponse(6L, "Backend", "직무")
+        new ActivityResponse(1L, "YAPP", "동아리"),
+        new ActivityResponse(2L, "DND", "동아리"),
+        new ActivityResponse(3L, "nexters", "동아리"),
+        new ActivityResponse(4L, "인프콘", "컨퍼런스"),
+        new ActivityResponse(5L, "우아한테크코스", "교육"),
+        new ActivityResponse(6L, "Backend", "직무")
     );
   }
 
@@ -128,12 +129,12 @@ class MemberApiTest extends MockMvcTestHelper {
     //given
     final String activityIds = "1,2";
 
-    final List<MemberActivityResponse> memberActivityResponses = List.of(
-        new MemberActivityResponse(3L, "nexters", "동아리")
+    final List<ActivityResponse> activityResponses = List.of(
+        new ActivityResponse(3L, "nexters", "동아리")
     );
 
     when(memberActivityCommandService.deleteActivity(any(), any()))
-        .thenReturn(memberActivityResponses);
+        .thenReturn(activityResponses);
 
     //when & then
     mockMvc.perform(
@@ -149,11 +150,10 @@ class MemberApiTest extends MockMvcTestHelper {
   @DisplayName("내 활동들을 조회할 수 있다.")
   void test_findActivity() throws Exception {
     //given
-    final List<MemberActivityResponse> memberActivityResponse = createMemberActivityResponses();
+    final List<ActivityResponse> memberActivityResponse = createActivityResponses();
 
     //when
-    when(memberActivityQueryService.findActivities(any()))
-        .thenReturn(memberActivityResponse);
+    when(memberActivityQueryService.findActivities(any())).thenReturn(memberActivityResponse);
 
     //then
     mockMvc.perform(get("/members/1/activities")

--- a/backend/emm-sale/src/main/java/com/emmsale/activity/application/dto/ActivityResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/activity/application/dto/ActivityResponse.java
@@ -1,9 +1,13 @@
 package com.emmsale.activity.application.dto;
 
 import com.emmsale.activity.domain.Activity;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 
 @RequiredArgsConstructor
+@ToString
+@Getter
 public class ActivityResponse {
 
   private final Long id;
@@ -12,21 +16,9 @@ public class ActivityResponse {
 
   public static ActivityResponse from(final Activity activity) {
     return new ActivityResponse(
-      activity.getId(),
-      activity.getActivityType().getValue(),
-      activity.getName()
+        activity.getId(),
+        activity.getActivityType().getValue(),
+        activity.getName()
     );
-  }
-
-  public Long getId() {
-    return id;
-  }
-
-  public String getActivityType() {
-    return activityType;
-  }
-
-  public String getName() {
-    return name;
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/member/api/MemberApi.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/api/MemberApi.java
@@ -1,5 +1,6 @@
 package com.emmsale.member.api;
 
+import com.emmsale.activity.application.dto.ActivityResponse;
 import com.emmsale.member.application.MemberActivityCommandService;
 import com.emmsale.member.application.MemberActivityQueryService;
 import com.emmsale.member.application.MemberCommandService;
@@ -46,7 +47,7 @@ public class MemberApi {
   }
 
   @PostMapping("/members/activities")
-  public ResponseEntity<List<MemberActivityResponse>> addActivity(
+  public ResponseEntity<List<ActivityResponse>> addActivity(
       final Member member,
       @RequestBody final MemberActivityAddRequest memberActivityAddRequest
   ) {
@@ -55,14 +56,14 @@ public class MemberApi {
   }
 
   @DeleteMapping("/members/activities")
-  public ResponseEntity<List<MemberActivityResponse>> deleteActivity(final Member member,
+  public ResponseEntity<List<ActivityResponse>> deleteActivity(final Member member,
       @RequestParam("activity-ids") final List<Long> deleteActivityIds) {
     return ResponseEntity.ok(
         memberActivityCommandService.deleteActivity(member, deleteActivityIds));
   }
 
   @GetMapping("/members/{member-id}/activities")
-  public ResponseEntity<List<MemberActivityResponse>> findActivity(
+  public ResponseEntity<List<ActivityResponse>> findActivity(
       @PathVariable("member-id") final Long memberId) {
     return ResponseEntity.ok(memberActivityQueryService.findActivities(memberId));
   }

--- a/backend/emm-sale/src/main/java/com/emmsale/member/application/MemberActivityCommandService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/application/MemberActivityCommandService.java
@@ -2,6 +2,7 @@ package com.emmsale.member.application;
 
 import static java.util.stream.Collectors.toUnmodifiableList;
 
+import com.emmsale.activity.application.dto.ActivityResponse;
 import com.emmsale.activity.domain.ActivityRepository;
 import com.emmsale.member.application.dto.MemberActivityAddRequest;
 import com.emmsale.member.application.dto.MemberActivityInitialRequest;
@@ -58,7 +59,7 @@ public class MemberActivityCommandService {
     }
   }
 
-  public List<MemberActivityResponse> addActivity(
+  public List<ActivityResponse> addActivity(
       final Member member,
       final MemberActivityAddRequest memberActivityAddRequest
   ) {
@@ -74,7 +75,8 @@ public class MemberActivityCommandService {
 
     return memberActivityRepository.findAllByMember(member)
         .stream()
-        .map(MemberActivityResponse::from)
+        .map(MemberActivity::getActivity)
+        .map(ActivityResponse::from)
         .collect(toUnmodifiableList());
   }
 
@@ -91,7 +93,7 @@ public class MemberActivityCommandService {
     return new HashSet<>(activityIds).size() != activityIds.size();
   }
 
-  public List<MemberActivityResponse> deleteActivity(
+  public List<ActivityResponse> deleteActivity(
       final Member member,
       final List<Long> deleteActivityIds
   ) {
@@ -105,7 +107,8 @@ public class MemberActivityCommandService {
 
     return memberActivityRepository.findAllByMember(member)
         .stream()
-        .map(MemberActivityResponse::from)
+        .map(MemberActivity::getActivity)
+        .map(ActivityResponse::from)
         .collect(toUnmodifiableList());
   }
 }

--- a/backend/emm-sale/src/main/java/com/emmsale/member/application/MemberActivityQueryService.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/member/application/MemberActivityQueryService.java
@@ -2,8 +2,9 @@ package com.emmsale.member.application;
 
 import static java.util.stream.Collectors.toUnmodifiableList;
 
-import com.emmsale.member.application.dto.MemberActivityResponse;
+import com.emmsale.activity.application.dto.ActivityResponse;
 import com.emmsale.member.domain.Member;
+import com.emmsale.member.domain.MemberActivity;
 import com.emmsale.member.domain.MemberActivityRepository;
 import com.emmsale.member.domain.MemberRepository;
 import java.util.List;
@@ -19,12 +20,13 @@ public class MemberActivityQueryService {
   private final MemberRepository memberRepository;
   private final MemberActivityRepository memberActivityRepository;
 
-  public List<MemberActivityResponse> findActivities(final Long memberId) {
+  public List<ActivityResponse> findActivities(final Long memberId) {
     final Member member = memberRepository.getByIdOrElseThrow(memberId);
 
     return memberActivityRepository.findAllByMember(member)
         .stream()
-        .map(MemberActivityResponse::from)
+        .map(MemberActivity::getActivity)
+        .map(ActivityResponse::from)
         .collect(toUnmodifiableList());
   }
 }

--- a/backend/emm-sale/src/test/java/com/emmsale/member/application/MemberActivityCommandServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/member/application/MemberActivityCommandServiceTest.java
@@ -6,10 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.emmsale.activity.application.dto.ActivityResponse;
 import com.emmsale.helper.ServiceIntegrationTestHelper;
 import com.emmsale.member.application.dto.MemberActivityAddRequest;
 import com.emmsale.member.application.dto.MemberActivityInitialRequest;
-import com.emmsale.member.application.dto.MemberActivityResponse;
 import com.emmsale.member.domain.Member;
 import com.emmsale.member.domain.MemberRepository;
 import com.emmsale.member.exception.MemberException;
@@ -84,17 +84,17 @@ class MemberActivityCommandServiceTest extends ServiceIntegrationTestHelper {
     final Member member = memberRepository.findById(savedMemberId).get();
     final MemberActivityAddRequest request = new MemberActivityAddRequest(activityIds);
 
-    final List<MemberActivityResponse> expected = List.of(
-        new MemberActivityResponse(1L, "YAPP", "동아리"),
-        new MemberActivityResponse(2L, "DND", "동아리"),
-        new MemberActivityResponse(3L, "nexters", "동아리"),
-        new MemberActivityResponse(5L, "인프콘", "컨퍼런스"),
-        new MemberActivityResponse(6L, "우아한테크코스", "교육"),
-        new MemberActivityResponse(7L, "Backend", "직무")
+    final List<ActivityResponse> expected = List.of(
+        new ActivityResponse(1L, "동아리", "YAPP"),
+        new ActivityResponse(2L, "동아리", "DND"),
+        new ActivityResponse(3L, "동아리", "nexters"),
+        new ActivityResponse(4L, "컨퍼런스", "인프콘"),
+        new ActivityResponse(5L, "교육", "우아한테크코스"),
+        new ActivityResponse(6L, "직무", "Backend")
     );
 
     //when
-    final List<MemberActivityResponse> actual = memberActivityCommandService.addActivity(member,
+    final List<ActivityResponse> actual = memberActivityCommandService.addActivity(member,
         request);
     //then
     assertThat(expected)
@@ -154,12 +154,12 @@ class MemberActivityCommandServiceTest extends ServiceIntegrationTestHelper {
 
     final Member member = memberRepository.findById(savedMemberId).get();
 
-    final List<MemberActivityResponse> expected = List.of(
-        new MemberActivityResponse(3L, "nexters", "동아리")
+    final List<ActivityResponse> expected = List.of(
+        new ActivityResponse(3L, "동아리", "nexters")
     );
 
     //when
-    final List<MemberActivityResponse> actual = memberActivityCommandService.deleteActivity(member,
+    final List<ActivityResponse> actual = memberActivityCommandService.deleteActivity(member,
         deleteActivityIds);
 
     //then

--- a/backend/emm-sale/src/test/java/com/emmsale/member/application/MemberActivityQueryServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/member/application/MemberActivityQueryServiceTest.java
@@ -1,0 +1,40 @@
+package com.emmsale.member.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.emmsale.activity.application.dto.ActivityResponse;
+import com.emmsale.helper.ServiceIntegrationTestHelper;
+import com.emmsale.member.domain.MemberRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class MemberActivityQueryServiceTest extends ServiceIntegrationTestHelper {
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @Autowired
+  private MemberActivityQueryService memberActivityQueryService;
+
+  @Test
+  @DisplayName("findActivities(): 유저의 Activity들을 조회한다.")
+  void findActivities() {
+    final Long memberId = 1L;
+
+    final List<ActivityResponse> actual
+        = memberActivityQueryService.findActivities(memberId);
+
+    final List<ActivityResponse> expected = List.of(
+        new ActivityResponse(1L, "동아리", "YAPP"),
+        new ActivityResponse(2L, "동아리", "DND"),
+        new ActivityResponse(3L, "동아리", "nexters")
+    );
+
+    assertThat(actual)
+        .usingRecursiveComparison()
+        .ignoringCollectionOrder()
+        .isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close : #840

## 📝 작업 내용
- memberActivity API에서 MemberActivityId가 아닌 ActivityId를 반환하도록 반환값 변경

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)
예상 소요 시간 : 30분
실제 소요 시간 : 1시간

