### PR TITLE
feat(EventInfoFragment): 지도 앱에 장소 검색하는 기능 추가

### DIFF
--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/eventDetailInfo/EventInfoFragment.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/eventDetailInfo/EventInfoFragment.kt
@@ -1,6 +1,9 @@
 package com.emmsale.presentation.ui.eventDetailInfo
 
+import android.content.ActivityNotFoundException
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.activityViewModels
@@ -9,6 +12,7 @@ import com.emmsale.databinding.FragmentEventInformationBinding
 import com.emmsale.presentation.base.BaseFragment
 import com.emmsale.presentation.common.firebase.analytics.FirebaseAnalyticsDelegate
 import com.emmsale.presentation.common.firebase.analytics.FirebaseAnalyticsDelegateImpl
+import com.emmsale.presentation.common.views.InfoDialog
 import com.emmsale.presentation.ui.eventDetail.EventDetailViewModel
 import com.emmsale.presentation.ui.eventDetailInfo.recyclerView.EventInfoImageAdapter
 import dagger.hilt.android.AndroidEntryPoint
@@ -27,8 +31,33 @@ class EventInfoFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.vm = viewModel
+
+        setupDataBinding()
         setUpInformationUrls()
+    }
+
+    private fun setupDataBinding() {
+        binding.vm = viewModel
+        binding.onMapSearchButtonClick = ::navigateToMapApp
+    }
+
+    private fun navigateToMapApp(location: String) {
+        val uri = Uri.parse("geo:0,0?q=$location")
+        val intent = Intent(Intent.ACTION_VIEW, uri)
+
+        runCatching { startActivity(intent) }
+            .onFailure {
+                if (it is ActivityNotFoundException) showNotFoundMapAppDialog()
+            }
+    }
+
+    private fun showNotFoundMapAppDialog() {
+        InfoDialog(
+            context = requireContext(),
+            title = getString(R.string.eventInfo_not_found_map_app_dialog_title),
+            message = getString(R.string.eventInfo_not_found_map_app_dialog_message),
+            buttonLabel = getString(R.string.all_okay),
+        ).show()
     }
 
     private fun setUpInformationUrls() {

--- a/android/2023-emmsale/app/src/main/res/drawable/ic_eventinformation_map.xml
+++ b/android/2023-emmsale/app/src/main/res/drawable/ic_eventinformation_map.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="@color/light_gray"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M14.65,4.98l-5,-1.75c-0.42,-0.15 -0.88,-0.15 -1.3,-0.01L4.36,4.56C3.55,4.84 3,5.6 3,6.46v11.85c0,1.41 1.41,2.37 2.72,1.86l2.93,-1.14c0.22,-0.09 0.47,-0.09 0.69,-0.01l5,1.75c0.42,0.15 0.88,0.15 1.3,0.01l3.99,-1.34c0.81,-0.27 1.36,-1.04 1.36,-1.9V5.69c0,-1.41 -1.41,-2.37 -2.72,-1.86l-2.93,1.14c-0.22,0.08 -0.46,0.09 -0.69,0.01zM15,18.89l-6,-2.11V5.11l6,2.11v11.67z"/>
+</vector>

--- a/android/2023-emmsale/app/src/main/res/layout/fragment_event_information.xml
+++ b/android/2023-emmsale/app/src/main/res/layout/fragment_event_information.xml
@@ -7,11 +7,19 @@
 
         <import type="android.view.View" />
 
+        <import type="kotlin.Unit" />
+
         <import type="com.emmsale.presentation.common.bindingadapter.DateTimePattern" />
+
+        <import type="com.emmsale.data.model.OnOfflineMode" />
 
         <variable
             name="vm"
             type="com.emmsale.presentation.ui.eventDetail.EventDetailViewModel" />
+
+        <variable
+            name="onMapSearchButtonClick"
+            type="kotlin.jvm.functions.Function1&lt;String, Unit>" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -108,19 +116,37 @@
 
                     <TextView
                         android:id="@+id/tv_event_info_place"
-                        android:layout_width="0dp"
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        app:layout_constraintHorizontal_bias="0"
+                        app:layout_constrainedWidth="true"
                         android:layout_marginStart="42dp"
                         android:layout_marginTop="10dp"
-                        android:layout_marginEnd="17dp"
                         android:fontFamily="@font/nanum_square_regular"
                         android:text="@{vm.event.location}"
                         android:textColor="@color/black"
                         android:textSize="12sp"
-                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintEnd_toStartOf="@id/iv_map_search"
                         app:layout_constraintStart_toEndOf="@+id/tv_event_info_place_title"
                         app:layout_constraintTop_toBottomOf="@id/tv_event_info_date"
-                        tools:text="삼성동 코엑스 몰 2층 101" />
+                        tools:text="삼성동 코엑스 몰 2층 101"
+                        app:layout_constraintHorizontal_chainStyle="packed" />
+
+                    <ImageView
+                        android:id="@+id/iv_map_search"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:src="@drawable/ic_eventinformation_map"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:layout_marginStart="5dp"
+                        android:layout_marginEnd="17dp"
+                        android:onClick="@{() -> onMapSearchButtonClick.invoke(tvEventInfoPlace.text)}"
+                        app:visible="@{vm.event.onOfflineMode != OnOfflineMode.ONLINE}"
+                        app:layout_constraintTop_toTopOf="@id/tv_event_info_place"
+                        app:layout_constraintBottom_toBottomOf="@id/tv_event_info_place"
+                        app:layout_constraintStart_toEndOf="@id/tv_event_info_place"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        android:contentDescription="@string/eventInfo_map_search_button_description" />
 
                     <TextView
                         android:id="@+id/tv_event_info_cost_title"

--- a/android/2023-emmsale/app/src/main/res/values/strings.xml
+++ b/android/2023-emmsale/app/src/main/res/values/strings.xml
@@ -254,6 +254,9 @@
     <string name="eventInfo_cost">비용</string>
     <string name="eventInfo_place">장소</string>
     <string name="eventInfo_date">일시</string>
+    <string name="eventInfo_map_search_button_description">지도 앱에 행사 장소 검색하는 버튼</string>
+    <string name="eventInfo_not_found_map_app_dialog_title">지도 앱 없음</string>
+    <string name="eventInfo_not_found_map_app_dialog_message">검색할 수 있는 지도 앱이 없습니다.</string>
 
     <string name="eventrecruitment_fetch_recruitments_error_message">글을 불러올 수 없습니다. 관리자에게 문의하세요.</string>
     <string name="eventrecruitment_has_not_permission_writing">모집글은 한 번만 작성이 가능합니다!!</string>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close : #876

## 📝 작업 내용

행사의 장소를 지도 앱에 검색하는 기능 추가

### 스크린샷 (선택)

![image](https://github.com/woowacourse-teams/2023-emmsale/assets/123928686/25e6ce87-58c2-4f54-979c-19296ab63994)


## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)
예상 소요 시간 : 2시간
실제 소요 시간 : 2시간

## 💬 리뷰어 요구사항 (선택)



