### PR TITLE
Fix/#895 채팅창에서 메세지 알림 클릭 시 버그

### DIFF
--- a/android/2023-emmsale/app/src/main/AndroidManifest.xml
+++ b/android/2023-emmsale/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         <activity android:name=".presentation.ui.feedDetail.FeedDetailActivity" />
         <activity
             android:name=".presentation.ui.messageList.MessageListActivity"
-            android:launchMode="singleTask"
+            android:launchMode="singleTop"
             android:parentActivityName=".presentation.ui.main.MainActivity"
             android:windowSoftInputMode="adjustResize" />
         <activity android:name=".presentation.ui.feedWriting.FeedWritingActivity" />

--- a/android/2023-emmsale/app/src/main/AndroidManifest.xml
+++ b/android/2023-emmsale/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         <activity android:name=".presentation.ui.feedDetail.FeedDetailActivity" />
         <activity
             android:name=".presentation.ui.messageList.MessageListActivity"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:parentActivityName=".presentation.ui.main.MainActivity"
             android:windowSoftInputMode="adjustResize" />
         <activity android:name=".presentation.ui.feedWriting.FeedWritingActivity" />

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageList/MessageListActivity.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageList/MessageListActivity.kt
@@ -109,7 +109,7 @@ class MessageListActivity :
         super.onNewIntent(intent)
 
         val roomId = intent.getStringExtra(KEY_ROOM_ID) ?: return
-        if (intent.getBooleanExtra(KEY_IS_SEND_BY_LOGIN_USER, false)) {
+        if (intent.getBooleanExtra(KEY_IS_SEND_NEW_MESSAGE_BY_LOGIN_USER, false)) {
             viewModel.refresh()
             smoothScrollToEnd()
             return
@@ -198,26 +198,27 @@ class MessageListActivity :
         private const val KEY_PROFILE_URL = "KEY_PROFILE_URL"
         private const val KEY_OTHER_NAME = "KEY_OTHER_NAME"
         private const val KEY_MESSAGE_CONTENT = "KEY_MESSAGE_CONTENT"
-        private const val KEY_IS_SEND_BY_LOGIN_USER = "KEY_IS_SEND_BY_LOGIN_USER"
+        private const val KEY_IS_SEND_NEW_MESSAGE_BY_LOGIN_USER =
+            "KEY_IS_SEND_NEW_MESSAGE_BY_LOGIN_USER"
 
         fun startActivity(
             context: Context,
             roomId: String,
             otherUid: Long,
-            isSendByLoginUser: Boolean = false,
+            isSendNewMessageByLoginUser: Boolean = false,
         ) {
-            context.startActivity(getIntent(context, roomId, otherUid, isSendByLoginUser))
+            context.startActivity(getIntent(context, roomId, otherUid, isSendNewMessageByLoginUser))
         }
 
         fun getIntent(
             context: Context,
             roomId: String,
             otherUid: Long,
-            isSendByLoginUser: Boolean = false,
+            isSendNewMessageByLoginUser: Boolean = false,
         ) = Intent(context, MessageListActivity::class.java)
             .putExtra(KEY_ROOM_ID, roomId)
             .putExtra(KEY_OTHER_UID, otherUid)
-            .putExtra(KEY_IS_SEND_BY_LOGIN_USER, isSendByLoginUser)
+            .putExtra(KEY_IS_SEND_NEW_MESSAGE_BY_LOGIN_USER, isSendNewMessageByLoginUser)
 
         fun getIntent(
             context: Context,

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageList/MessageListActivity.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageList/MessageListActivity.kt
@@ -143,7 +143,11 @@ class MessageListActivity :
                 message = messageContent,
                 notificationId = otherRoomId.hashCode(),
                 channelId = R.id.id_all_message_notification_channel,
-                intent = intent,
+                intent = getIntent(
+                    this@MessageListActivity,
+                    otherRoomId,
+                    viewModel.otherMember.value!!.id,
+                ),
                 largeIconUrl = profileUrl,
                 groupKey = otherRoomId,
             )

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageList/MessageListActivity.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/messageList/MessageListActivity.kt
@@ -109,6 +109,12 @@ class MessageListActivity :
         super.onNewIntent(intent)
 
         val roomId = intent.getStringExtra(KEY_ROOM_ID) ?: return
+        if (intent.getBooleanExtra(KEY_IS_SEND_BY_LOGIN_USER, false)) {
+            viewModel.refresh()
+            smoothScrollToEnd()
+            return
+        }
+
         val profileUrl = intent.getStringExtra(KEY_PROFILE_URL)
         val otherName = intent.getStringExtra(KEY_OTHER_NAME) ?: return
         val messageContent = intent.getStringExtra(KEY_MESSAGE_CONTENT) ?: return
@@ -192,18 +198,26 @@ class MessageListActivity :
         private const val KEY_PROFILE_URL = "KEY_PROFILE_URL"
         private const val KEY_OTHER_NAME = "KEY_OTHER_NAME"
         private const val KEY_MESSAGE_CONTENT = "KEY_MESSAGE_CONTENT"
+        private const val KEY_IS_SEND_BY_LOGIN_USER = "KEY_IS_SEND_BY_LOGIN_USER"
 
-        fun startActivity(context: Context, roomId: String, otherUid: Long) {
-            context.startActivity(getIntent(context, roomId, otherUid))
+        fun startActivity(
+            context: Context,
+            roomId: String,
+            otherUid: Long,
+            isSendByLoginUser: Boolean = false,
+        ) {
+            context.startActivity(getIntent(context, roomId, otherUid, isSendByLoginUser))
         }
 
         fun getIntent(
             context: Context,
             roomId: String,
             otherUid: Long,
+            isSendByLoginUser: Boolean = false,
         ) = Intent(context, MessageListActivity::class.java)
             .putExtra(KEY_ROOM_ID, roomId)
             .putExtra(KEY_OTHER_UID, otherUid)
+            .putExtra(KEY_IS_SEND_BY_LOGIN_USER, isSendByLoginUser)
 
         fun getIntent(
             context: Context,

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/profile/ProfileActivity.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/profile/ProfileActivity.kt
@@ -148,6 +148,7 @@ class ProfileActivity : NetworkActivity<ActivityProfileBinding>(R.layout.activit
                     this,
                     uiEvent.roomId,
                     uiEvent.otherId,
+                    true,
                 )
                 sendMessageDialog.clearText()
                 sendMessageDialog.dismiss()

--- a/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/recruitmentDetail/RecruitmentDetailActivity.kt
+++ b/android/2023-emmsale/app/src/main/java/com/emmsale/presentation/ui/recruitmentDetail/RecruitmentDetailActivity.kt
@@ -143,6 +143,7 @@ class RecruitmentDetailActivity :
                     this,
                     uiEvent.roomId,
                     uiEvent.otherId,
+                    true,
                 )
                 sendMessageDialog.clearText()
                 sendMessageDialog.dismiss()


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close : #895

## 📝 작업 내용

채팅창에서 다른 채팅창의 메세지 알림이 왔을 때 그 알림 클릭하면 다른 채팅창으로 이동하도록 수정했습니다. 원래는 이동하지 않았습니다. 제가 리팩터링 하면서 잘못 구현했습니다.

그리고 프로필 화면 간 다음 거기서 쪽지 보내면 방금 보낸 쪽지가 보이지 않았습니다. 이유는 `onNewIntent()`가 호출되었기 때문입니다. 따라서 로그인한 사용자가 메세지 보내서 `onNewIntent()`가 호출된 거라면 새로고침하도록 수정하였습니다. 근데 이건 디자인을 수정해야 할 문제 같습니다. 프로필 화면에서 메세지 다이얼로그 띄워서 메세지를 보내는 것보단 그냥 채팅창 화면으로 이동할 수 있게 하는 게 더 나을 것 같아요. 만약 한 번도 채팅하지 않아서 roomId가 없다면 카카오톡처럼 빈 화면을 보여주게 하면 좋을 것 같아요. 이 부분은 어떻게 생각하시나요?

### 스크린샷 (선택)

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)
예상 소요 시간 : 5분
실제 소요 시간 : 40분

## 💬 리뷰어 요구사항 (선택)



