### PR TITLE
Feat/#893 행사 목록 조회 api 반환값 변경

### DIFF
--- a/backend/emm-sale/src/documentTest/java/com/emmsale/EventApiTest.java
+++ b/backend/emm-sale/src/documentTest/java/com/emmsale/EventApiTest.java
@@ -24,6 +24,7 @@ import com.emmsale.event.domain.PaymentType;
 import com.emmsale.member.domain.Member;
 import com.emmsale.tag.TagFixture;
 import com.emmsale.tag.application.dto.TagRequest;
+import com.emmsale.tag.application.dto.TagResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.HashMap;
@@ -76,6 +77,8 @@ class EventApiTest extends MockMvcTestHelper {
           .description("신청 종료일자(nullable)"),
       fieldWithPath("location").type(JsonFieldType.STRING).description("장소"),
       fieldWithPath("tags[]").type(JsonFieldType.ARRAY).description("태그들"),
+      fieldWithPath("tags[].id").type(JsonFieldType.NUMBER).description("행사 태그 ID"),
+      fieldWithPath("tags[].name").type(JsonFieldType.STRING).description("행사 태그 이름"),
       fieldWithPath("thumbnailUrl").type(JsonFieldType.STRING)
           .description("섬네일 이미지 Url(포스터)"),
       fieldWithPath("type").type(JsonFieldType.STRING)
@@ -100,7 +103,9 @@ class EventApiTest extends MockMvcTestHelper {
       fieldWithPath("[].applyEndDate").type(JsonFieldType.STRING)
           .description("행사 신청 종료 일자(nullable)"),
       fieldWithPath("[].location").type(JsonFieldType.STRING).description("행사 장소"),
-      fieldWithPath("[].tags[]").type(JsonFieldType.ARRAY).description("행사 태그들"),
+      fieldWithPath("[].tags[]").type(JsonFieldType.ARRAY).description("태그들"),
+      fieldWithPath("[].tags[].id").type(JsonFieldType.NUMBER).description("행사 태그 ID"),
+      fieldWithPath("[].tags[].name").type(JsonFieldType.STRING).description("행사 태그 이름"),
       fieldWithPath("[].thumbnailUrl").type(JsonFieldType.STRING)
           .description("행사 섬네일 이미지 Url(포스터)"),
       fieldWithPath("[].type").type(JsonFieldType.STRING)
@@ -116,11 +121,14 @@ class EventApiTest extends MockMvcTestHelper {
   void findEvent() throws Exception {
     //given
     final Long eventId = 1L;
+    final List<TagResponse> tagResponses = List.of(
+        new TagResponse(1L, "코틀린"), new TagResponse(2L, "백엔드"), new TagResponse(3L, "안드로이드")
+    );
     final EventResponse eventResponse = new EventResponse(eventId, "인프콘 2023",
         "http://infcon.com", LocalDateTime.of(2023, 8, 15, 12, 0),
         LocalDateTime.of(2023, 8, 15, 12, 0), LocalDateTime.of(2023, 8, 1, 12, 0),
         LocalDateTime.of(2023, 8, 15, 12, 0), "코엑스",
-        List.of("코틀린", "백엔드", "안드로이드"),
+        tagResponses,
         "https://www.image.com", EventType.COMPETITION.toString(),
         List.of("imageUrl1", "imageUrl2"), "인프런", "유료", "온라인");
 
@@ -163,7 +171,7 @@ class EventApiTest extends MockMvcTestHelper {
             LocalDateTime.parse("2023-08-03T12:00:00"),
             LocalDateTime.parse("2023-06-23T10:00:00"),
             LocalDateTime.parse("2023-07-03T12:00:00"),
-            "코엑스", List.of("백엔드", "프론트엔드"),
+            "코엑스", List.of(new TagResponse(1L, "백엔드"), new TagResponse(2L, "프론트엔드")),
             "imageUrl0", EventType.CONFERENCE.name(),
             List.of("imageUrl1", "imageUrl2"), "인프런",
             PaymentType.PAID.getValue(),
@@ -175,7 +183,7 @@ class EventApiTest extends MockMvcTestHelper {
             LocalDateTime.parse("2023-07-30T12:00:00"),
             LocalDateTime.parse("2023-07-01T00:00:00"),
             LocalDateTime.parse("2023-07-21T23:59:59"),
-            "코엑스", List.of("AI"),
+            "코엑스", List.of(new TagResponse(5L, "AI")),
             "imageUrl0", EventType.CONFERENCE.name(),
             List.of("imageUrl1", "imageUrl2"), "인프런",
             PaymentType.PAID.getValue(),
@@ -234,7 +242,7 @@ class EventApiTest extends MockMvcTestHelper {
         request.getInformationUrl(), request.getStartDateTime(), request.getEndDateTime(),
         request.getApplyStartDateTime(), request.getApplyEndDateTime(),
         request.getLocation(),
-        tags.stream().map(TagRequest::getName).collect(Collectors.toList()),
+        List.of(new TagResponse(1L, "백엔드"), new TagResponse(2L, "안드로이드")),
         "image1.jpg", request.getType().toString(),
         List.of("imageUrl1", "imageUrl2"), "행사기관", "유료", "온라인");
 
@@ -339,7 +347,7 @@ class EventApiTest extends MockMvcTestHelper {
           request.getInformationUrl(), request.getStartDateTime(), request.getEndDateTime(),
           request.getApplyStartDateTime(), request.getApplyEndDateTime(),
           request.getLocation(),
-          tags.stream().map(TagRequest::getName).collect(Collectors.toList()),
+          List.of(new TagResponse(1L, "백엔드"), new TagResponse(2L, "안드로이드")),
           "image1.jpg", request.getType().toString(),
           List.of("imageUrl1", "imageUrl2"), "행사기관", "무료", "오프라인");
 

--- a/backend/emm-sale/src/documentTest/java/com/emmsale/ScrapApiTest.java
+++ b/backend/emm-sale/src/documentTest/java/com/emmsale/ScrapApiTest.java
@@ -16,6 +16,7 @@ import com.emmsale.event.domain.EventType;
 import com.emmsale.event.domain.PaymentType;
 import com.emmsale.scrap.api.ScrapApi;
 import com.emmsale.scrap.application.dto.ScrapRequest;
+import com.emmsale.tag.application.dto.TagResponse;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -31,7 +32,13 @@ import org.springframework.restdocs.payload.ResponseFieldsSnippet;
 @WebMvcTest(ScrapApi.class)
 class ScrapApiTest extends MockMvcTestHelper {
 
-  final ResponseFieldsSnippet SCRAPPED_EVENT_RESPONSE_FIELDS = PayloadDocumentation.responseFields(
+  private static final List<TagResponse> TAG_RESPONSES = List.of(
+      new TagResponse(1L, "백엔드"), new TagResponse(2L, "프론트엔드"),
+      new TagResponse(3L, "안드로이드"), new TagResponse(4L, "IOS"),
+      new TagResponse(5L, "AI")
+  );
+
+  static final ResponseFieldsSnippet SCRAPPED_EVENT_RESPONSE_FIELDS = PayloadDocumentation.responseFields(
       fieldWithPath("id").type(JsonFieldType.NUMBER).description("행사 식별자"),
       fieldWithPath("name").type(JsonFieldType.STRING)
           .description("행사 이름"),
@@ -45,7 +52,9 @@ class ScrapApiTest extends MockMvcTestHelper {
       fieldWithPath("applyEndDate").type(JsonFieldType.STRING)
           .description("행사 신청 종료 일자(nullable)"),
       fieldWithPath("location").type(JsonFieldType.STRING).description("행사 장소"),
-      fieldWithPath("tags[]").type(JsonFieldType.ARRAY).description("행사 태그들"),
+      fieldWithPath("tags[]").type(JsonFieldType.ARRAY).description("태그들"),
+      fieldWithPath("tags[].id").type(JsonFieldType.NUMBER).description("행사 태그 ID"),
+      fieldWithPath("tags[].name").type(JsonFieldType.STRING).description("행사 태그 이름"),
       fieldWithPath("thumbnailUrl").type(JsonFieldType.STRING)
           .description("행사 섬네일 이미지 Url(포스터)"),
       fieldWithPath("type").type(JsonFieldType.STRING)
@@ -70,7 +79,7 @@ class ScrapApiTest extends MockMvcTestHelper {
             LocalDateTime.parse("2023-09-01T00:00:00"),
             LocalDateTime.parse("2023-09-02T23:59:59"),
             "코엑스",
-            List.of("백엔드", "프론트엔드", "안드로이드", "IOS", "AI"),
+            TAG_RESPONSES,
             "image0.jpg",
             EventType.CONFERENCE.name(),
             List.of("image1.jpg", "image2.jpg", "image3.jpg"),
@@ -87,7 +96,7 @@ class ScrapApiTest extends MockMvcTestHelper {
             LocalDateTime.parse("2023-09-01T00:00:00"),
             LocalDateTime.parse("2023-09-02T23:59:59"),
             "코엑스",
-            List.of("백엔드", "프론트엔드", "안드로이드", "IOS", "AI"),
+            TAG_RESPONSES,
             "image0.jpg",
             EventType.CONFERENCE.name(),
             List.of("image1.jpg", "image2.jpg", "image3.jpg"),
@@ -102,7 +111,7 @@ class ScrapApiTest extends MockMvcTestHelper {
             LocalDateTime.parse("2023-09-01T00:00:00"),
             LocalDateTime.parse("2023-09-02T23:59:59"),
             "코엑스",
-            List.of("백엔드", "프론트엔드", "안드로이드", "IOS", "AI"),
+            TAG_RESPONSES,
             "image0.jpg",
             EventType.CONFERENCE.name(),
             List.of("image1.jpg", "image2.jpg", "image3.jpg"),
@@ -125,7 +134,9 @@ class ScrapApiTest extends MockMvcTestHelper {
         fieldWithPath("[].applyEndDate").type(JsonFieldType.STRING)
             .description("행사 신청 종료 일자(nullable)"),
         fieldWithPath("[].location").type(JsonFieldType.STRING).description("행사 장소"),
-        fieldWithPath("[].tags[]").type(JsonFieldType.ARRAY).description("행사 태그들"),
+        fieldWithPath("[].tags[]").type(JsonFieldType.ARRAY).description("태그들"),
+        fieldWithPath("[].tags[].id").type(JsonFieldType.NUMBER).description("행사 태그 ID"),
+        fieldWithPath("[].tags[].name").type(JsonFieldType.STRING).description("행사 태그 이름"),
         fieldWithPath("[].thumbnailUrl").type(JsonFieldType.STRING)
             .description("행사 섬네일 이미지 Url(포스터)"),
         fieldWithPath("[].type").type(JsonFieldType.STRING)
@@ -161,7 +172,7 @@ class ScrapApiTest extends MockMvcTestHelper {
         LocalDateTime.parse("2023-09-01T00:00:00"),
         LocalDateTime.parse("2023-09-02T23:59:59"),
         "코엑스",
-        List.of("백엔드", "프론트엔드", "안드로이드", "IOS", "AI"),
+        TAG_RESPONSES,
         "image0.jpg",
         EventType.CONFERENCE.name(),
         List.of("image1.jpg", "image2.jpg", "image3.jpg"),
@@ -199,7 +210,7 @@ class ScrapApiTest extends MockMvcTestHelper {
         LocalDateTime.parse("2023-09-01T00:00:00"),
         LocalDateTime.parse("2023-09-02T23:59:59"),
         "코엑스",
-        List.of("백엔드", "프론트엔드", "안드로이드", "IOS", "AI"),
+        TAG_RESPONSES,
         "image0.jpg",
         EventType.CONFERENCE.name(),
         List.of("image1.jpg", "image2.jpg", "image3.jpg"),

--- a/backend/emm-sale/src/main/java/com/emmsale/event/application/dto/EventResponse.java
+++ b/backend/emm-sale/src/main/java/com/emmsale/event/application/dto/EventResponse.java
@@ -6,7 +6,7 @@ import com.emmsale.event.domain.Event;
 import com.emmsale.event.domain.EventStatus;
 import com.emmsale.event.domain.EventTag;
 import com.emmsale.image.domain.AllImagesOfContent;
-import com.emmsale.tag.domain.Tag;
+import com.emmsale.tag.application.dto.TagResponse;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -34,7 +34,7 @@ public class EventResponse {
   @JsonFormat(pattern = DATE_TIME_FORMAT)
   private final LocalDateTime applyEndDate;
   private final String location;
-  private final List<String> tags;
+  private final List<TagResponse> tags;
   private final String thumbnailUrl;
   private final String type;
   private final List<String> imageUrls;
@@ -46,9 +46,9 @@ public class EventResponse {
       final Event event,
       final AllImagesOfContent images
   ) {
-    final List<String> tagNames = event.getTags().stream()
+    final List<TagResponse> tagResponses = event.getTags().stream()
         .map(EventTag::getTag)
-        .map(Tag::getName)
+        .map(TagResponse::from)
         .collect(toUnmodifiableList());
 
     return new EventResponse(
@@ -60,7 +60,7 @@ public class EventResponse {
         event.getEventPeriod().getApplyStartDate(),
         event.getEventPeriod().getApplyEndDate(),
         event.getLocation(),
-        tagNames,
+        tagResponses,
         images.extractThumbnailImage(),
         event.getType().toString(),
         images.extractInformationImages(),

--- a/backend/emm-sale/src/test/java/com/emmsale/admin/event/application/EventCommandServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/admin/event/application/EventCommandServiceTest.java
@@ -160,6 +160,13 @@ class EventCommandServiceTest extends ServiceIntegrationTestHelper {
       final Event savedEvent = eventRepository.findById(response.getId()).get();
 
       //then
+      assertThat(response.getTags())
+          .extracting("name")
+          .containsExactlyInAnyOrderElementsOf(
+              tagRequests.stream()
+                  .map(TagRequest::getName)
+                  .collect(Collectors.toList())
+          );
       assertAll(
           () -> assertEquals(eventName, savedEvent.getName()),
           () -> assertEquals(eventLocation, savedEvent.getLocation()),
@@ -167,13 +174,6 @@ class EventCommandServiceTest extends ServiceIntegrationTestHelper {
           () -> assertEquals(beforeDateTime, savedEvent.getEventPeriod().getStartDate()),
           () -> assertEquals(afterDateTime, savedEvent.getEventPeriod().getEndDate())
       );
-      assertThat(response.getTags())
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              tagRequests.stream()
-                  .map(TagRequest::getName)
-                  .collect(Collectors.toList())
-          );
     }
 
     @Test
@@ -320,6 +320,13 @@ class EventCommandServiceTest extends ServiceIntegrationTestHelper {
       final Event updatedEvent = eventRepository.findById(eventId).get();
 
       //then
+      assertThat(response.getTags())
+          .extracting("name")
+          .containsExactlyInAnyOrderElementsOf(
+              newTagRequests.stream()
+                  .map(TagRequest::getName)
+                  .collect(Collectors.toList())
+          );
       assertAll(
           () -> assertEquals(newName, updatedEvent.getName()),
           () -> assertEquals(newLocation, updatedEvent.getLocation()),
@@ -327,13 +334,6 @@ class EventCommandServiceTest extends ServiceIntegrationTestHelper {
           () -> assertEquals(newEndDateTime, updatedEvent.getEventPeriod().getEndDate()),
           () -> assertEquals(newInformationUrl, updatedEvent.getInformationUrl())
       );
-      assertThat(response.getTags())
-          .extracting("name")
-          .containsExactlyInAnyOrder(
-              newTagRequests.stream()
-                  .map(TagRequest::getName)
-                  .collect(Collectors.toList())
-          );
     }
 
     @Test

--- a/backend/emm-sale/src/test/java/com/emmsale/admin/event/application/EventCommandServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/admin/event/application/EventCommandServiceTest.java
@@ -168,7 +168,8 @@ class EventCommandServiceTest extends ServiceIntegrationTestHelper {
           () -> assertEquals(afterDateTime, savedEvent.getEventPeriod().getEndDate())
       );
       assertThat(response.getTags())
-          .containsAll(
+          .extracting("name")
+          .containsExactlyInAnyOrder(
               tagRequests.stream()
                   .map(TagRequest::getName)
                   .collect(Collectors.toList())
@@ -327,7 +328,8 @@ class EventCommandServiceTest extends ServiceIntegrationTestHelper {
           () -> assertEquals(newInformationUrl, updatedEvent.getInformationUrl())
       );
       assertThat(response.getTags())
-          .containsAll(
+          .extracting("name")
+          .containsExactlyInAnyOrder(
               newTagRequests.stream()
                   .map(TagRequest::getName)
                   .collect(Collectors.toList())

--- a/backend/emm-sale/src/test/java/com/emmsale/event/application/EventQueryServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/event/application/EventQueryServiceTest.java
@@ -39,6 +39,7 @@ import com.emmsale.image.domain.AllImagesOfContent;
 import com.emmsale.image.domain.Image;
 import com.emmsale.image.domain.ImageType;
 import com.emmsale.image.domain.repository.ImageRepository;
+import com.emmsale.tag.application.dto.TagResponse;
 import com.emmsale.tag.domain.Tag;
 import com.emmsale.tag.domain.TagRepository;
 import com.emmsale.tag.exception.TagException;
@@ -58,32 +59,33 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 class EventQueryServiceTest extends ServiceIntegrationTestHelper {
 
+  private static final TagResponse 백엔드 = new TagResponse(1L, "백엔드");
   private static final EventResponse 인프콘_2023 = new EventResponse(null, "인프콘 2023",
-      null, null, null, null, null, "코엑스", List.of("백엔드"),
+      null, null, null, null, null, "코엑스", List.of(백엔드),
       "이미지1", EventType.CONFERENCE.name(), List.of(), "인프런", PaymentType.PAID.getValue(),
       EventMode.OFFLINE.getValue());
   private static final EventResponse 웹_컨퍼런스 = new EventResponse(null, "웹 컨퍼런스", null,
       null, null,
-      null, null, "코엑스", List.of("백엔드"), "이미지1", EventType.CONFERENCE.name(),
+      null, null, "코엑스", List.of(백엔드), "이미지1", EventType.CONFERENCE.name(),
       List.of(), "주최기관", PaymentType.PAID.getValue(), EventMode.ONLINE.getValue());
   private static final EventResponse 안드로이드_컨퍼런스 = new EventResponse(null, "안드로이드 컨퍼런스",
-      null, null, null, null, null, "코엑스", List.of("백엔드"),
+      null, null, null, null, null, "코엑스", List.of(백엔드),
       "이미지1", EventType.CONFERENCE.name(), List.of(), "주최기관", PaymentType.PAID.getValue(),
       EventMode.ONLINE.getValue());
   private static final EventResponse AI_컨퍼런스 = new EventResponse(null, "AI 컨퍼런스",
-      null, null, null, null, null, "코엑스", List.of("백엔드"),
+      null, null, null, null, null, "코엑스", List.of(백엔드),
       "이미지1", EventType.CONFERENCE.name(), List.of(), "주최기관", PaymentType.PAID.getValue(),
       EventMode.ONLINE.getValue());
   private static final EventResponse 모바일_컨퍼런스 = new EventResponse(null, "모바일 컨퍼런스",
-      null, null, null, null, null, "코엑스", List.of("백엔드"),
+      null, null, null, null, null, "코엑스", List.of(백엔드),
       "이미지1", EventType.CONFERENCE.name(), List.of(), "주최기관", PaymentType.PAID.getValue(),
       EventMode.ONLINE.getValue());
   private static final EventResponse AI_아이디어_공모전 = new EventResponse(null,
       "AI 아이디어 공모전", null, null, null, null, null, "코엑스",
-      List.of("백엔드"), "이미지1", EventType.CONFERENCE.name(), List.of(), "주최기관",
+      List.of(백엔드), "이미지1", EventType.CONFERENCE.name(), List.of(), "주최기관",
       PaymentType.PAID.getValue(), EventMode.ONLINE.getValue());
   private static final EventResponse 구름톤 = new EventResponse(null, "구름톤", null,
-      null, null, null, null, "코엑스", List.of("백엔드"),
+      null, null, null, null, "코엑스", List.of(백엔드),
       "이미지1", EventType.COMPETITION.name(), List.of(), "주최기관", PaymentType.PAID.getValue(),
       EventMode.ONLINE.getValue());
 
@@ -468,7 +470,7 @@ class EventQueryServiceTest extends ServiceIntegrationTestHelper {
       final List<EventResponse> actualEvents = eventQueryService.findEvents(
           EventType.CONFERENCE,
           TODAY,
-          null, null, List.of("안드로이드", "백엔드"), null, null);
+          null, null, List.of("안드로이드", 백엔드.getName()), null, null);
 
       // then
       assertThat(actualEvents)
@@ -539,7 +541,8 @@ class EventQueryServiceTest extends ServiceIntegrationTestHelper {
       final List<EventResponse> actualEvents = eventQueryService.findEvents(
           EventType.CONFERENCE,
           TODAY,
-          "2023-09-01", "2023-09-30", List.of("안드로이드", "백엔드"), List.of(EventStatus.UPCOMING), null);
+          "2023-09-01", "2023-09-30", List.of("안드로이드", 백엔드.getName())
+          , List.of(EventStatus.UPCOMING), null);
 
       // then
       assertThat(actualEvents)

--- a/backend/emm-sale/src/test/java/com/emmsale/scrap/application/ScrapQueryServiceTest.java
+++ b/backend/emm-sale/src/test/java/com/emmsale/scrap/application/ScrapQueryServiceTest.java
@@ -17,7 +17,7 @@ import com.emmsale.member.domain.Member;
 import com.emmsale.member.domain.MemberRepository;
 import com.emmsale.scrap.domain.Scrap;
 import com.emmsale.scrap.domain.ScrapRepository;
-import com.emmsale.tag.domain.Tag;
+import com.emmsale.tag.application.dto.TagResponse;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
@@ -63,7 +63,7 @@ class ScrapQueryServiceTest extends ServiceIntegrationTestHelper {
             event1.getTags()
                 .stream()
                 .map(EventTag::getTag)
-                .map(Tag::getName)
+                .map(TagResponse::from)
                 .collect(Collectors.toList()),
             행사_이미지1(event1.getId()).getName(), event1.getType().name(),
             List.of(행사_이미지2(event1.getId()).getName(), 행사_이미지3(event1.getId()).getName(),
@@ -77,7 +77,7 @@ class ScrapQueryServiceTest extends ServiceIntegrationTestHelper {
             event2.getTags()
                 .stream()
                 .map(EventTag::getTag)
-                .map(Tag::getName)
+                .map(TagResponse::from)
                 .collect(Collectors.toList()),
             null, event2.getType().name(),
             List.of(),


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> close : # 893

## 📝 작업 내용

- EventResponse 반환값에 tag id 추가

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)
예상 소요 시간 : 2시간
실제 소요 시간 : 4시간

